### PR TITLE
fix: prevent token shadowing/aliasing from bypassing CPU feature checks

### DIFF
--- a/archmage-macros/src/arcane.rs
+++ b/archmage-macros/src/arcane.rs
@@ -13,6 +13,43 @@ use syn::{
 use crate::common::*;
 use crate::token_discovery::*;
 
+/// Generate a compile-time assertion that the token parameter is a genuine
+/// archmage token of the expected type.
+///
+/// For **concrete tokens** (e.g., `X64V3Token`): asserts the exact type via
+/// `::archmage::X64V3Token`, catching both shadowing (local struct with the
+/// same name) and aliasing (e.g., `use archmage::X64V2Token as X64V3Token`).
+///
+/// For **trait/generic bounds** (e.g., `impl HasX64V2`, `T: HasNeon`): falls
+/// back to checking `SimdToken` (sealed trait), which catches shadowing but
+/// cannot catch cross-trait aliasing.
+///
+/// Both forms are zero-cost: the generated code is optimized away entirely.
+fn gen_token_assertion(
+    token_type_name: &Option<String>,
+    token_ident: &Ident,
+) -> proc_macro2::TokenStream {
+    if let Some(name) = token_type_name {
+        // Concrete token: verify the exact type via fully-qualified path.
+        // This catches both shadowing (non-archmage type) and aliasing
+        // (wrong archmage token renamed to match this name).
+        let expected_type = format_ident!("{}", name);
+        quote! {
+            // Compile-time proof that the token is genuinely ::archmage::#expected_type.
+            // Catches name shadowing (local struct) and aliasing (wrong token renamed).
+            {
+                fn __archmage_verify(_: &::archmage::#expected_type) {}
+                __archmage_verify(&#token_ident);
+            }
+        }
+    } else {
+        // Trait/generic bound: can only verify SimdToken (sealed).
+        quote! {
+            ::archmage::__private::assert_archmage_token(&#token_ident);
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct ArcaneArgs {
     /// Use `#[inline(always)]` instead of `#[inline]` for the inner function.
@@ -138,7 +175,7 @@ pub(crate) fn arcane_impl(
 
     // Find the token parameter, its features, target arch, and token type name
     let TokenParamInfo {
-        ident: _token_ident,
+        ident: mut _token_ident,
         features,
         target_arch,
         token_type_name,
@@ -267,6 +304,12 @@ pub(crate) fn arcane_impl(
             #(#pattern_rebinds)*
             #original_body
         };
+        // Pattern renaming may have changed the token parameter's ident
+        // (e.g., wildcard `_: X64V3Token` → `__archmage_arg_0: X64V3Token`).
+        // Re-discover the correct ident from the modified signature.
+        if let Some(info) = find_token_param(&input_fn.sig) {
+            _token_ident = info.ident;
+        }
     }
 
     // Choose inline attribute based on args
@@ -297,6 +340,7 @@ pub(crate) fn arcane_impl(
             token_type_name,
             target_feature_attrs,
             inline_attr,
+            _token_ident,
         )
     } else {
         arcane_impl_sibling(
@@ -306,6 +350,7 @@ pub(crate) fn arcane_impl(
             token_type_name,
             target_feature_attrs,
             inline_attr,
+            _token_ident,
         )
     }
 }
@@ -431,6 +476,7 @@ pub(crate) fn arcane_impl_sibling(
     token_type_name: Option<String>,
     target_feature_attrs: Vec<Attribute>,
     inline_attr: Attribute,
+    token_ident: Ident,
 ) -> TokenStream {
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
@@ -537,11 +583,13 @@ pub(crate) fn arcane_impl_sibling(
         // Wrapper function: fn original_name(...) { unsafe { sibling_call } }
         // The unsafe block is needed because the sibling has #[target_feature] and
         // the wrapper doesn't — calling across this boundary requires unsafe.
+        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
         let wrapper_fn = quote! {
             #cfg_guard
             #(#attrs)*
             #[inline(always)]
             #vis #sig {
+                #token_assertion
                 // SAFETY: The token parameter proves the required CPU features are available.
                 // Calling a #[target_feature] function from a non-matching context requires
                 // unsafe because the CPU may not support those instructions. The token's
@@ -630,6 +678,7 @@ pub(crate) fn arcane_impl_nested(
     token_type_name: Option<String>,
     target_feature_attrs: Vec<Attribute>,
     inline_attr: Attribute,
+    token_ident: Ident,
 ) -> TokenStream {
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
@@ -762,6 +811,7 @@ pub(crate) fn arcane_impl_nested(
             quote! {}
         };
 
+        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
         quote! {
             // Real implementation for the correct architecture
             #cfg_guard
@@ -775,6 +825,7 @@ pub(crate) fn arcane_impl_nested(
                     #inner_body
                 }
 
+                #token_assertion
                 // SAFETY: The token parameter proves the required CPU features are available.
                 unsafe { #inner_fn_name #turbofish(#(#inner_args),*) }
             }
@@ -783,6 +834,7 @@ pub(crate) fn arcane_impl_nested(
         }
     } else {
         // No specific arch (trait bounds or generic) - generate without cfg guards
+        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
         quote! {
             #(#attrs)*
             #[inline(always)]
@@ -794,6 +846,7 @@ pub(crate) fn arcane_impl_nested(
                     #inner_body
                 }
 
+                #token_assertion
                 // SAFETY: The token proves the required CPU features are available.
                 unsafe { #inner_fn_name #turbofish(#(#inner_args),*) }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,33 @@ pub mod testing;
 // Use `magetypes::simd` for f32x8, i32x4, etc.
 
 // ============================================================================
+// Private module for macro-generated assertions
+// ============================================================================
+
+/// Internal module used by `#[arcane]` macro output. Not part of the public API.
+///
+/// The `#[arcane]` macro emits a call to `assert_archmage_token` in every wrapper
+/// function to prevent token shadowing attacks. Without this, a user could create
+/// a local struct with the same name as an archmage token (e.g., `struct X64V3Token;`),
+/// and the macro — which does name-based feature lookup — would generate
+/// `#[target_feature(enable = "avx2,fma,...")]` + `unsafe { ... }` for the impostor,
+/// enabling UB on CPUs that lack those features.
+///
+/// The assertion is zero-cost: it compiles to nothing, but enforces that the
+/// token type implements [`SimdToken`], which requires the sealed `Sealed` trait
+/// that only archmage's own tokens can implement.
+#[doc(hidden)]
+pub mod __private {
+    /// Compile-time assertion that `T` is a genuine archmage token.
+    ///
+    /// Called by macro-generated wrappers. Optimized away entirely — exists
+    /// only to produce a compile error if the token type doesn't implement
+    /// [`SimdToken`](crate::SimdToken) (which is sealed).
+    #[inline(always)]
+    pub fn assert_archmage_token<T: crate::SimdToken>(_: &T) {}
+}
+
+// ============================================================================
 // Re-exports at crate root for convenience
 // ============================================================================
 

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -36,7 +36,11 @@ mod sealed {
     pub trait Sealed {}
 }
 
-pub use sealed::Sealed;
+// Sealed is pub(crate) — external crates cannot implement SimdToken.
+// This is a semver break from 0.9.17 (Sealed was accidentally pub), but
+// necessary: the public re-export allowed external SimdToken impls,
+// undermining the entire token safety model.
+pub(crate) use sealed::Sealed;
 
 /// Marker trait for SIMD capability tokens.
 ///

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -42,4 +42,10 @@ fn ui_tests() {
 
     // #[autoversion] rejects concrete tokens
     t.compile_fail("tests/compile_fail/autoversion_concrete_token.rs");
+
+    // Token shadowing: local struct with same name as archmage token must fail
+    t.compile_fail("tests/compile_fail/token_shadowing.rs");
+
+    // Token aliasing: renaming a lower-tier token to a higher-tier name must fail
+    t.compile_fail("tests/compile_fail/token_aliasing.rs");
 }

--- a/tests/compile_fail/token_aliasing.rs
+++ b/tests/compile_fail/token_aliasing.rs
@@ -1,0 +1,13 @@
+// Token aliasing: renaming a lower-tier token to a higher-tier name
+// must NOT compile. The macro generates #[target_feature] based on the
+// name, but the actual token only proves lesser features are available.
+
+use archmage::arcane;
+use archmage::X64V2Token as X64V3Token;
+
+#[arcane]
+fn evil(token: X64V3Token, data: &[f32; 8]) -> f32 {
+    data.iter().sum()
+}
+
+fn main() {}

--- a/tests/compile_fail/token_aliasing.stderr
+++ b/tests/compile_fail/token_aliasing.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+ --> tests/compile_fail/token_aliasing.rs:8:1
+  |
+8 | #[arcane]
+  | ^^^^^^^^^
+  | |
+  | expected `&X64V3Token`, found `&X64V2Token`
+  | arguments to this function are incorrect
+  |
+  = note: expected reference `&X64V3Token`
+             found reference `&X64V2Token`
+note: function defined here
+ --> tests/compile_fail/token_aliasing.rs:8:1
+  |
+8 | #[arcane]
+  | ^^^^^^^^^
+  = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused variable: `token`
+ --> tests/compile_fail/token_aliasing.rs:9:9
+  |
+9 | fn evil(token: X64V3Token, data: &[f32; 8]) -> f32 {
+  |         ^^^^^ help: if this is intentional, prefix it with an underscore: `_token`
+  |
+  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

--- a/tests/compile_fail/token_shadowing.rs
+++ b/tests/compile_fail/token_shadowing.rs
@@ -1,0 +1,16 @@
+// Token shadowing: a local struct with the same name as an archmage token
+// must NOT compile when used with #[arcane]. The assert_archmage_token check
+// catches this because the shadowed type doesn't implement SimdToken (sealed).
+
+use archmage::arcane;
+
+// Shadow the real X64V3Token with a local imposter
+#[derive(Clone, Copy)]
+struct X64V3Token;
+
+#[arcane]
+fn evil(_token: X64V3Token, data: &[f32; 8]) -> f32 {
+    data.iter().sum()
+}
+
+fn main() {}

--- a/tests/compile_fail/token_shadowing.stderr
+++ b/tests/compile_fail/token_shadowing.stderr
@@ -1,0 +1,26 @@
+error[E0308]: mismatched types
+  --> tests/compile_fail/token_shadowing.rs:11:1
+   |
+11 | #[arcane]
+   | ^^^^^^^^^
+   | |
+   | expected `archmage::X64V3Token`, found `X64V3Token`
+   | arguments to this function are incorrect
+   |
+   = note: `X64V3Token` and `archmage::X64V3Token` have similar names, but are actually distinct types
+note: `X64V3Token` is defined in the current crate
+  --> tests/compile_fail/token_shadowing.rs:9:1
+   |
+ 9 | struct X64V3Token;
+   | ^^^^^^^^^^^^^^^^^
+note: `archmage::X64V3Token` is defined in crate `archmage`
+  --> src/tokens/generated/x86.rs
+   |
+   | pub struct X64V3Token {
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: function defined here
+  --> tests/compile_fail/token_shadowing.rs:11:1
+   |
+11 | #[arcane]
+   | ^^^^^^^^^
+   = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/expand/arcane/associated_type_bound.expanded.rs
+++ b/tests/expand/arcane/associated_type_bound.expanded.rs
@@ -16,6 +16,10 @@ fn sum_iter<I>(token: X64V3Token, iter: I) -> f32
 where
     I: Iterator<Item = f32>,
 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_sum_iter::<I>(token, iter) }
 }
 fn main() {}

--- a/tests/expand/arcane/box_dyn_return.expanded.rs
+++ b/tests/expand/arcane/box_dyn_return.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_make_adder(token: X64V3Token, offset: f32) -> Box<dyn Fn(f32) -> f32
 }
 #[inline(always)]
 fn make_adder(token: X64V3Token, offset: f32) -> Box<dyn Fn(f32) -> f32> {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_make_adder(token, offset) }
 }
 fn main() {}

--- a/tests/expand/arcane/closure_param.expanded.rs
+++ b/tests/expand/arcane/closure_param.expanded.rs
@@ -14,6 +14,10 @@ fn __arcane_apply(
 }
 #[inline(always)]
 fn apply(token: X64V3Token, data: &[f32; 4], f: impl Fn(f32) -> f32) -> [f32; 4] {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_apply(token, data, f) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_array.expanded.rs
+++ b/tests/expand/arcane/destructured_array.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: [f32; 4]) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: [f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_nested.expanded.rs
+++ b/tests/expand/arcane/destructured_nested.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: ((f32, f32), f32)) -> f
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: ((f32, f32), f32)) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_tuple.expanded.rs
+++ b/tests/expand/arcane/destructured_tuple.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: (f32, f32)) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: (f32, f32)) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/dyn_trait_param.expanded.rs
+++ b/tests/expand/arcane/dyn_trait_param.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(token: X64V3Token, callback: &dyn Fn(f32) -> f32, x: f32) ->
 }
 #[inline(always)]
 fn process(token: X64V3Token, callback: &dyn Fn(f32) -> f32, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, callback, x) }
 }
 fn main() {}

--- a/tests/expand/arcane/fn_ptr_param.expanded.rs
+++ b/tests/expand/arcane/fn_ptr_param.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_apply_fn(token: X64V3Token, f: fn(f32) -> f32, x: f32) -> f32 {
 }
 #[inline(always)]
 fn apply_fn(token: X64V3Token, f: fn(f32) -> f32, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_apply_fn(token, f, x) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_const.expanded.rs
+++ b/tests/expand/arcane/generic_const.expanded.rs
@@ -14,6 +14,10 @@ fn __arcane_sum_n<const N: usize>(token: X64V3Token, data: &[f32; N]) -> f32 {
 }
 #[inline(always)]
 fn sum_n<const N: usize>(token: X64V3Token, data: &[f32; N]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_sum_n::<N>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_lifetime.expanded.rs
+++ b/tests/expand/arcane/generic_lifetime.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process<'a>(token: X64V3Token, data: &'a [f32]) -> &'a f32 {
 }
 #[inline(always)]
 fn process<'a>(token: X64V3Token, data: &'a [f32]) -> &'a f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_lifetime_and_type.expanded.rs
+++ b/tests/expand/arcane/generic_lifetime_and_type.expanded.rs
@@ -13,6 +13,10 @@ fn __arcane_first_n<'a, T: Copy, const N: usize>(
 }
 #[inline(always)]
 fn first_n<'a, T: Copy, const N: usize>(token: X64V3Token, data: &'a [T; N]) -> &'a T {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_first_n::<T, N>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_multi_params.expanded.rs
+++ b/tests/expand/arcane/generic_multi_params.expanded.rs
@@ -11,6 +11,10 @@ fn __arcane_add_items<T: Add<Output = T> + Copy>(token: X64V3Token, a: T, b: T) 
 }
 #[inline(always)]
 fn add_items<T: Add<Output = T> + Copy>(token: X64V3Token, a: T, b: T) -> T {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_add_items::<T>(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_where_clause.expanded.rs
+++ b/tests/expand/arcane/generic_where_clause.expanded.rs
@@ -20,6 +20,10 @@ fn sum_slice<T>(token: X64V3Token, data: &[T]) -> f32
 where
     T: Copy + Into<f32>,
 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_sum_slice::<T>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/higher_ranked_trait_bound.expanded.rs
+++ b/tests/expand/arcane/higher_ranked_trait_bound.expanded.rs
@@ -16,6 +16,10 @@ fn apply_ref<F>(token: X64V3Token, f: F, data: &[f32]) -> f32
 where
     F: for<'a> Fn(&'a [f32]) -> f32,
 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_apply_ref::<F>(token, f, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/import_intrinsics.expanded.rs
+++ b/tests/expand/arcane/import_intrinsics.expanded.rs
@@ -16,6 +16,10 @@ fn __arcane_process(token: X64V3Token, a: &[f32; 8], b: &[f32; 8]) -> [f32; 8] {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: &[f32; 8], b: &[f32; 8]) -> [f32; 8] {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/multi_bounds.expanded.rs
+++ b/tests/expand/arcane/multi_bounds.expanded.rs
@@ -17,6 +17,10 @@ fn fma<T>(token: X64V3Token, a: T, b: T, c: T) -> T
 where
     T: Copy + Mul<Output = T> + Add<Output = T>,
 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_fma::<T>(token, a, b, c) }
 }
 fn main() {}

--- a/tests/expand/arcane/multiple_wildcards.expanded.rs
+++ b/tests/expand/arcane/multiple_wildcards.expanded.rs
@@ -20,6 +20,10 @@ fn process(
     __archmage_arg_1: f32,
     __archmage_arg_2: f32,
 ) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&__archmage_arg_0);
+    }
     unsafe { __arcane_process(__archmage_arg_0, __archmage_arg_1, __archmage_arg_2) }
 }
 fn main() {}

--- a/tests/expand/arcane/nested.expanded.rs
+++ b/tests/expand/arcane/nested.expanded.rs
@@ -8,6 +8,10 @@ fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
     fn __simd_inner_process(token: X64V3Token, a: f32, b: f32) -> f32 {
         a + b
     }
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __simd_inner_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/nested_self.expanded.rs
+++ b/tests/expand/arcane/nested_self.expanded.rs
@@ -12,6 +12,10 @@ impl Processor {
         fn __simd_inner_process(_self: &Processor, token: X64V3Token, a: f32) -> f32 {
             _self.val + a
         }
+        {
+            fn __archmage_verify(_: &::archmage::X64V3Token) {}
+            __archmage_verify(&token);
+        }
         unsafe { __simd_inner_process(self, token, a) }
     }
 }

--- a/tests/expand/arcane/return_impl_trait.expanded.rs
+++ b/tests/expand/arcane/return_impl_trait.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_make_iter(token: X64V3Token, data: &[f32]) -> impl Iterator<Item = &
 }
 #[inline(always)]
 fn make_iter(token: X64V3Token, data: &[f32]) -> impl Iterator<Item = &f32> {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_make_iter(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/sibling.expanded.rs
+++ b/tests/expand/arcane/sibling.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_process(token: X64V3Token, a: f32, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_first.expanded.rs
+++ b/tests/expand/arcane/token_first.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(token: X64V3Token, a: f32, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_generic.expanded.rs
+++ b/tests/expand/arcane/token_generic.expanded.rs
@@ -7,6 +7,7 @@ fn __arcane_process<T: HasX64V2>(token: T, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process<T: HasX64V2>(token: T, a: f32) -> f32 {
+    ::archmage::__private::assert_archmage_token(&token);
     unsafe { __arcane_process::<T>(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_last.expanded.rs
+++ b/tests/expand/arcane/token_last.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(a: f32, b: f32, token: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn process(a: f32, b: f32, token: X64V3Token) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(a, b, token) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_middle.expanded.rs
+++ b/tests/expand/arcane/token_middle.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(a: f32, token: X64V3Token, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(a: f32, token: X64V3Token, b: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(a, token, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_trait_bound.expanded.rs
+++ b/tests/expand/arcane/token_trait_bound.expanded.rs
@@ -7,6 +7,7 @@ fn __arcane_process(token: impl HasX64V2, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: impl HasX64V2, a: f32) -> f32 {
+    ::archmage::__private::assert_archmage_token(&token);
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v2.expanded.rs
+++ b/tests/expand/arcane/token_v2.expanded.rs
@@ -7,6 +7,10 @@ fn __arcane_process(token: X64V2Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V2Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V2Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v3.expanded.rs
+++ b/tests/expand/arcane/token_v3.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v4.expanded.rs
+++ b/tests/expand/arcane/token_v4.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_process(token: X64V4Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V4Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/unsafe_fn.expanded.rs
+++ b/tests/expand/arcane/unsafe_fn.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_process(token: X64V3Token, ptr: *const f32) -> f32 {
 }
 #[inline(always)]
 unsafe fn process(token: X64V3Token, ptr: *const f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, ptr) }
 }
 fn main() {}

--- a/tests/expand/arcane/wildcard_token.expanded.rs
+++ b/tests/expand/arcane/wildcard_token.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_process(__archmage_arg_0: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(__archmage_arg_0: X64V3Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&__archmage_arg_0);
+    }
     unsafe { __arcane_process(__archmage_arg_0, a) }
 }
 fn main() {}

--- a/tests/expand/autoversion/basic.expanded.rs
+++ b/tests/expand/autoversion/basic.expanded.rs
@@ -23,6 +23,10 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -37,6 +41,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/cfg_feature.expanded.rs
+++ b/tests/expand/autoversion/cfg_feature.expanded.rs
@@ -14,6 +14,10 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -28,6 +32,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/default_tier.expanded.rs
+++ b/tests/expand/autoversion/default_tier.expanded.rs
@@ -23,6 +23,10 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -37,6 +41,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_gated.expanded.rs
+++ b/tests/expand/autoversion/explicit_gated.expanded.rs
@@ -20,6 +20,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_v3_neon_scalar.expanded.rs
+++ b/tests/expand/autoversion/explicit_v3_neon_scalar.expanded.rs
@@ -20,6 +20,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_v3_scalar.expanded.rs
+++ b/tests/expand/autoversion/explicit_v3_scalar.expanded.rs
@@ -20,6 +20,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/plain_self.expanded.rs
+++ b/tests/expand/autoversion/plain_self.expanded.rs
@@ -27,6 +27,10 @@ impl P {
     #[allow(dead_code)]
     #[inline(always)]
     fn apply_v4(&self, _token: archmage::X64V4Token, x: f32) -> f32 {
+        {
+            fn __archmage_verify(_: &::archmage::X64V4Token) {}
+            __archmage_verify(&_token);
+        }
         unsafe { self.__arcane_apply_v4(_token, x) }
     }
     #[doc(hidden)]
@@ -41,6 +45,10 @@ impl P {
     #[allow(dead_code)]
     #[inline(always)]
     fn apply_v3(&self, _token: archmage::X64V3Token, x: f32) -> f32 {
+        {
+            fn __archmage_verify(_: &::archmage::X64V3Token) {}
+            __archmage_verify(&_token);
+        }
         unsafe { self.__arcane_apply_v3(_token, x) }
     }
     #[allow(dead_code)]

--- a/tests/expand/autoversion/scalar_token.expanded.rs
+++ b/tests/expand/autoversion/scalar_token.expanded.rs
@@ -23,6 +23,10 @@ fn __arcane_process_v4(token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v4(token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process_v4(token, data) }
 }
 #[doc(hidden)]
@@ -37,6 +41,10 @@ fn __arcane_process_v3(token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v3(token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process_v3(token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/self_type.expanded.rs
+++ b/tests/expand/autoversion/self_type.expanded.rs
@@ -30,6 +30,10 @@ impl P {
         ) -> f32 {
             x * _self.f
         }
+        {
+            fn __archmage_verify(_: &::archmage::X64V4Token) {}
+            __archmage_verify(&_token);
+        }
         unsafe { __simd_inner_apply_v4(self, _token, x) }
     }
     #[allow(dead_code)]
@@ -46,6 +50,10 @@ impl P {
             x: f32,
         ) -> f32 {
             x * _self.f
+        }
+        {
+            fn __archmage_verify(_: &::archmage::X64V3Token) {}
+            __archmage_verify(&_token);
         }
         unsafe { __simd_inner_apply_v3(self, _token, x) }
     }

--- a/tests/expand/autoversion/tier_modifiers.expanded.rs
+++ b/tests/expand/autoversion/tier_modifiers.expanded.rs
@@ -23,6 +23,10 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -37,6 +41,10 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/unsafe_fn.expanded.rs
+++ b/tests/expand/autoversion/unsafe_fn.expanded.rs
@@ -31,6 +31,10 @@ fn __arcane_process_v4(
 #[allow(dead_code)]
 #[inline(always)]
 unsafe fn process_v4(_token: archmage::X64V4Token, ptr: *const f32, len: usize) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_process_v4(_token, ptr, len) }
 }
 #[doc(hidden)]
@@ -53,6 +57,10 @@ fn __arcane_process_v3(
 #[allow(dead_code)]
 #[inline(always)]
 unsafe fn process_v3(_token: archmage::X64V3Token, ptr: *const f32, len: usize) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_process_v3(_token, ptr, len) }
 }
 #[allow(dead_code)]

--- a/tests/expand/combinations/arcane_calls_rite.expanded.rs
+++ b/tests/expand/combinations/arcane_calls_rite.expanded.rs
@@ -22,6 +22,10 @@ fn __arcane_process(token: X64V3Token, data: &[f32; 4]) -> [f32; 4] {
 }
 #[inline(always)]
 fn process(token: X64V3Token, data: &[f32; 4]) -> [f32; 4] {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, data) }
 }
 fn main() {}

--- a/tests/expand/combinations/autoversion_chain.expanded.rs
+++ b/tests/expand/combinations/autoversion_chain.expanded.rs
@@ -23,6 +23,10 @@ fn __arcane_inner_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn inner_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_inner_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -37,6 +41,10 @@ fn __arcane_inner_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn inner_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_inner_v3(_token, data) }
 }
 #[allow(dead_code)]
@@ -67,6 +75,10 @@ fn __arcane_outer_v4(_token: archmage::X64V4Token, data: &[f32; 4], scale: f32) 
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v4(_token: archmage::X64V4Token, data: &[f32; 4], scale: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_outer_v4(_token, data, scale) }
 }
 #[doc(hidden)]
@@ -81,6 +93,10 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, data: &[f32; 4], scale: f32) 
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, data: &[f32; 4], scale: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_outer_v3(_token, data, scale) }
 }
 #[allow(dead_code)]

--- a/tests/expand/combinations/token_downgrade.expanded.rs
+++ b/tests/expand/combinations/token_downgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_v3_helper(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v3_helper(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_v3_helper(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_v4_caller(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v4_caller(token: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_v4_caller(token, x) }
 }
 fn main() {}

--- a/tests/expand/combinations/token_upgrade.expanded.rs
+++ b/tests/expand/combinations/token_upgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_v4_fast(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v4_fast(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_v4_fast(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_v3_with_upgrade(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v3_with_upgrade(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_v3_with_upgrade(_t, x) }
 }
 fn main() {}

--- a/tests/expand/deprecated/autoversion_simdtoken.expanded.rs
+++ b/tests/expand/deprecated/autoversion_simdtoken.expanded.rs
@@ -33,6 +33,10 @@ fn __arcane_process_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_process_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -47,6 +51,10 @@ fn __arcane_process_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_process_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/deprecated/dispatch_variant.expanded.rs
+++ b/tests/expand/deprecated/dispatch_variant.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_compute_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn compute_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_compute_v3(_t, x) }
 }
 fn compute_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/deprecated/simd_fn.expanded.rs
+++ b/tests/expand/deprecated/simd_fn.expanded.rs
@@ -12,6 +12,10 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 #[allow(deprecated)]
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/deprecated/simd_route.expanded.rs
+++ b/tests/expand/deprecated/simd_route.expanded.rs
@@ -10,6 +10,10 @@ fn __arcane_compute_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn compute_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_compute_v3(_t, x) }
 }
 fn compute_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/deprecated/token_target_features_boundary.expanded.rs
+++ b/tests/expand/deprecated/token_target_features_boundary.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/incant/default_tiers.expanded.rs
+++ b/tests/expand/incant/default_tiers.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/feature_gated.expanded.rs
+++ b/tests/expand/incant/feature_gated.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/tier_modifiers.expanded.rs
+++ b/tests/expand/incant/tier_modifiers.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/token_explicit_first.expanded.rs
+++ b/tests/expand/incant/token_explicit_first.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/token_explicit_last.expanded.rs
+++ b/tests/expand/incant/token_explicit_last.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(x: f32, _t: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(x: f32, _t: X64V3Token) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(x, _t) }
 }
 fn inner_scalar(x: f32, _t: ScalarToken) -> f32 {

--- a/tests/expand/incant/token_prepend.expanded.rs
+++ b/tests/expand/incant/token_prepend.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/arcane_downgrade.expanded.rs
+++ b/tests/expand/rewrite/arcane_downgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -36,6 +44,10 @@ fn __arcane_outer(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_exact.expanded.rs
+++ b/tests/expand/rewrite/arcane_exact.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -36,6 +44,10 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_named_token.expanded.rs
+++ b/tests/expand/rewrite/arcane_named_token.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -24,6 +28,10 @@ fn __arcane_outer(alligator: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(alligator: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&alligator);
+    }
     unsafe { __arcane_outer(alligator, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_token_last.expanded.rs
+++ b/tests/expand/rewrite/arcane_token_last.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(x: f32, _t: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(x: f32, _t: X64V3Token) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(x, _t) }
 }
 fn inner_scalar(x: f32, _t: ScalarToken) -> f32 {
@@ -24,6 +28,10 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_upgrade.expanded.rs
+++ b/tests/expand/rewrite/arcane_upgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -39,6 +47,10 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_upgrade_gated.expanded.rs
+++ b/tests/expand/rewrite/arcane_upgrade_gated.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -39,6 +47,10 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/autoversion_exact.expanded.rs
+++ b/tests/expand/rewrite/autoversion_exact.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -47,6 +55,10 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/autoversion_upgrade.expanded.rs
+++ b/tests/expand/rewrite/autoversion_upgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -50,6 +58,10 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/autoversion_upgrade_gated.expanded.rs
+++ b/tests/expand/rewrite/autoversion_upgrade_gated.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -21,6 +25,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -50,6 +58,10 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/cross_branch_no_downgrade.expanded.rs
+++ b/tests/expand/rewrite/cross_branch_no_downgrade.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3_crypto(_t: X64V3CryptoToken, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3_crypto(_t: X64V3CryptoToken, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3CryptoToken) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3_crypto(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -30,6 +34,10 @@ fn __arcane_outer(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V4Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V4Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/rite_exact.expanded.rs
+++ b/tests/expand/rewrite/rite_exact.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/rite_multi.expanded.rs
+++ b/tests/expand/rewrite/rite_multi.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/rite_tokenless_passthrough.expanded.rs
+++ b/tests/expand/rewrite/rite_tokenless_passthrough.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_t);
+    }
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/scalar_fallback.expanded.rs
+++ b/tests/expand/rewrite/scalar_fallback.expanded.rs
@@ -12,6 +12,10 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&token);
+    }
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/should-fail/autoversion_trait_impl.expanded.rs
+++ b/tests/expand/should-fail/autoversion_trait_impl.expanded.rs
@@ -39,6 +39,10 @@ impl Process for Filter {
             }
             sum
         }
+        {
+            fn __archmage_verify(_: &::archmage::X64V4Token) {}
+            __archmage_verify(&_token);
+        }
         unsafe { __simd_inner_process_v4(self, _token, data) }
     }
     #[allow(dead_code)]
@@ -61,6 +65,10 @@ impl Process for Filter {
                 }
             }
             sum
+        }
+        {
+            fn __archmage_verify(_: &::archmage::X64V3Token) {}
+            __archmage_verify(&_token);
         }
         unsafe { __simd_inner_process_v3(self, _token, data) }
     }

--- a/tests/expand/should-fail/autoversion_trait_impl.expanded.stderr
+++ b/tests/expand/should-fail/autoversion_trait_impl.expanded.stderr
@@ -9,35 +9,35 @@ error[E0407]: method `process_v4` is not a member of trait `Process`
 25 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe,pclmulqdq,aes,av...
 26 | |         )]
 ...  |
-42 | |         unsafe { __simd_inner_process_v4(self, _token, data) }
-43 | |     }
+46 | |         unsafe { __simd_inner_process_v4(self, _token, data) }
+47 | |     }
    | |_____^ not a member of trait `Process`
 
 error[E0407]: method `process_v3` is not a member of trait `Process`
-  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:46:5
+  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:50:5
    |
-46 |       fn process_v3(&self, _token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+50 |       fn process_v3(&self, _token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
    |       ^  ---------- help: there is an associated function with a similar name: `process`
    |  _____|
    | |
-47 | |         #[target_feature(
-48 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe"
-49 | |         )]
+51 | |         #[target_feature(
+52 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe"
+53 | |         )]
 ...  |
-65 | |         unsafe { __simd_inner_process_v3(self, _token, data) }
-66 | |     }
+73 | |         unsafe { __simd_inner_process_v3(self, _token, data) }
+74 | |     }
    | |_____^ not a member of trait `Process`
 
 error[E0407]: method `process_scalar` is not a member of trait `Process`
-  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:68:5
+  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:76:5
    |
-68 | /     fn process_scalar(&self, _token: archmage::ScalarToken, data: &[f32; 4]) -> f32 {
-69 | |         let _self = self;
-70 | |         let mut sum = 0.0f32;
-71 | |         for &x in data {
+76 | /     fn process_scalar(&self, _token: archmage::ScalarToken, data: &[f32; 4]) -> f32 {
+77 | |         let _self = self;
+78 | |         let mut sum = 0.0f32;
+79 | |         for &x in data {
 ...  |
-76 | |         sum
-77 | |     }
+84 | |         sum
+85 | |     }
    | |_____^ not a member of trait `Process`
 
 warning: unused import: `archmage::autoversion`

--- a/tests/expand/should-fail/incant_passthrough.expanded.rs
+++ b/tests/expand/should-fail/incant_passthrough.expanded.rs
@@ -9,6 +9,10 @@ fn __arcane_inner_v3(_token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_token: X64V3Token, x: f32) -> f32 {
+    {
+        fn __archmage_verify(_: &::archmage::X64V3Token) {}
+        __archmage_verify(&_token);
+    }
     unsafe { __arcane_inner_v3(_token, x) }
 }
 fn inner_scalar(_token: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/should-fail/incant_passthrough.expanded.stderr
+++ b/tests/expand/should-fail/incant_passthrough.expanded.stderr
@@ -7,13 +7,13 @@ warning: unused imports: `NeonToken`, `arcane`, and `incant`
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
 
 error[E0658]: use of unstable library feature `panic_internals`: internal details of the implementation of the `panic!` and related macros
-  --> tests/expand/should-fail/incant_passthrough.expanded.rs:30:13
+  --> tests/expand/should-fail/incant_passthrough.expanded.rs:34:13
    |
-30 |             ::core::panicking::panic_fmt(
+34 |             ::core::panicking::panic_fmt(
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused import: `archmage::IntoConcreteToken`
-  --> tests/expand/should-fail/incant_passthrough.expanded.rs:19:13
+  --> tests/expand/should-fail/incant_passthrough.expanded.rs:23:13
    |
-19 |         use archmage::IntoConcreteToken;
+23 |         use archmage::IntoConcreteToken;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/soundness/sealed_trait_bypass.stderr
+++ b/tests/soundness/sealed_trait_bypass.stderr
@@ -1,0 +1,15 @@
+error[E0603]: trait `Sealed` is private
+  --> tests/soundness/sealed_trait_bypass.rs:19:24
+   |
+19 | impl archmage::tokens::Sealed for FakeToken {}
+   |                        ^^^^^^ private trait
+   |
+note: the trait `Sealed` is defined here
+  --> src/tokens/mod.rs
+   |
+   | pub(crate) use sealed::Sealed;
+   |                ^^^^^^^^^^^^^^
+help: import `Sealed` directly
+   |
+19 | impl archmage::tokens::sealed::Sealed for FakeToken {}
+   |                        ++++++++

--- a/tests/soundness/token_aliasing_exploit.stderr
+++ b/tests/soundness/token_aliasing_exploit.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> tests/soundness/token_aliasing_exploit.rs:15:1
+   |
+15 | #[arcane]
+   | ^^^^^^^^^
+   | |
+   | expected `&X64V3Token`, found `&X64V2Token`
+   | arguments to this function are incorrect
+   |
+   = note: expected reference `&X64V3Token`
+              found reference `&X64V2Token`
+note: function defined here
+  --> tests/soundness/token_aliasing_exploit.rs:15:1
+   |
+15 | #[arcane]
+   | ^^^^^^^^^
+   = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused variable: `token`
+  --> tests/soundness/token_aliasing_exploit.rs:16:9
+   |
+16 | fn evil(token: X64V3Token, data: &[f32; 8]) -> f32 {
+   |         ^^^^^ help: if this is intentional, prefix it with an underscore: `_token`
+   |
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

--- a/tests/soundness/token_shadowing_exploit.stderr
+++ b/tests/soundness/token_shadowing_exploit.stderr
@@ -1,0 +1,26 @@
+error[E0308]: mismatched types
+  --> tests/soundness/token_shadowing_exploit.rs:18:1
+   |
+18 | #[arcane]
+   | ^^^^^^^^^
+   | |
+   | expected `archmage::X64V3Token`, found `X64V3Token`
+   | arguments to this function are incorrect
+   |
+   = note: `X64V3Token` and `archmage::X64V3Token` have similar names, but are actually distinct types
+note: `X64V3Token` is defined in the current crate
+  --> tests/soundness/token_shadowing_exploit.rs:16:1
+   |
+16 | struct X64V3Token;
+   | ^^^^^^^^^^^^^^^^^
+note: `archmage::X64V3Token` is defined in crate `archmage`
+  --> src/tokens/generated/x86.rs
+   |
+   | pub struct X64V3Token {
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: function defined here
+  --> tests/soundness/token_shadowing_exploit.rs:18:1
+   |
+18 | #[arcane]
+   | ^^^^^^^^^
+   = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/soundness_exploits.rs
+++ b/tests/soundness_exploits.rs
@@ -1,15 +1,16 @@
 //! Soundness exploit regression tests.
 //!
-//! These tests use compile_fail to assert that each exploit SHOULD NOT compile.
-//! On unfixed code, the exploits DO compile — so these tests FAIL, proving the
-//! vulnerability exists. On fixed code, the exploits are blocked and tests pass.
+//! These tests verify that token soundness vulnerabilities are blocked.
+//! Each test file in tests/soundness/ attempts a specific exploit that
+//! MUST fail to compile.
 //!
-//! CI red = vulnerability confirmed. CI green = vulnerability fixed.
+//! **Before the fix:** These compiled successfully (t.pass), proving the exploits worked.
+//! **After the fix:** All are compile_fail, proving the exploits are blocked.
 
 #![cfg(target_arch = "x86_64")]
 
 #[test]
-fn soundness_exploits_must_not_compile() {
+fn soundness_exploits_blocked() {
     let t = trybuild::TestCases::new();
 
     // Token shadowing: local struct must not bypass CPU feature detection


### PR DESCRIPTION
## Summary

Fixes three soundness vulnerabilities in the `#[arcane]` macro's token validation. Regression tests in #28 prove these exploits exist on unfixed code.

### Vulnerabilities fixed

1. **Sealed trait leak** — `pub use sealed::Sealed` re-exported the sealed trait publicly, allowing external crates to implement `SimdToken` for arbitrary types. Changed to `pub(crate)`.

2. **Token shadowing** — The macro does name-based feature lookup (`token_to_features("X64V3Token")`), so a local `struct X64V3Token;` gets `#[target_feature(enable = "avx2,fma,...")]` with no CPU check. **Fix:** For concrete tokens, the macro now emits a type assertion against the fully-qualified path:
   ```rust
   {
       fn __archmage_verify(_: &::archmage::X64V3Token) {}
       __archmage_verify(&token);
   }
   ```
   Zero-cost (optimized away), but fails compilation if the type isn't genuinely `::archmage::X64V3Token`.

3. **Token aliasing** — `use archmage::X64V2Token as X64V3Token` passes the `SimdToken` check but gets V3 features for a V2 token. The fully-qualified type assertion catches this too: `expected &X64V3Token, found &X64V2Token`.

For **trait/generic bounds** (`impl HasX64V2`, `T: HasNeon`), falls back to `SimdToken` (sealed) check — trait aliasing is harder to exploit and all tier traits chain to `SimdToken`.

### Changes

- `src/tokens/mod.rs`: `pub use sealed::Sealed` → `pub(crate) use sealed::Sealed`
- `src/lib.rs`: Add `__private::assert_archmage_token` for trait/generic fallback
- `archmage-macros/src/arcane.rs`: Add `gen_token_assertion()` emitting type-specific or trait-based assertion in every `#[arcane]` wrapper
- `tests/compile_fail/`: Token shadowing + aliasing compile-fail tests
- `tests/soundness/`: Converted from `t.pass()` → `t.compile_fail()` (the three exploits from #28)

## Test plan

- [x] All existing tests pass (`cargo test --features "std avx512"` — 0 failures)
- [x] External crate tests pass (avx512-cfg-tests, no-features-crate)
- [x] Shadowed token: `error[E0308]: expected archmage::X64V3Token, found X64V3Token`
- [x] Aliased token: `error[E0308]: expected &X64V3Token, found &X64V2Token`
- [x] Sealed bypass: `error[E0603]: trait Sealed is private`
- [x] Macro expansion snapshots regenerated