### PR TITLE
Replace ::archmage:: path assertion with const tier tag check

### DIFF
--- a/archmage-macros/src/arcane.rs
+++ b/archmage-macros/src/arcane.rs
@@ -16,38 +16,40 @@ use crate::token_discovery::*;
 /// Generate a compile-time assertion that the token parameter is a genuine
 /// archmage token of the expected type.
 ///
-/// For **concrete tokens** (e.g., `X64V3Token`): asserts the exact type via
-/// `::archmage::X64V3Token`, catching both shadowing (local struct with the
-/// same name) and aliasing (e.g., `use archmage::X64V2Token as X64V3Token`).
+/// For **concrete tokens** (e.g., `X64V3Token`): emits a `const` assertion
+/// comparing `<Type>::__ARCHMAGE_TIER_TAG` against the expected tag value.
+/// The `Type` is the full path from the function signature (not just the
+/// last segment), so it resolves through re-exports without requiring
+/// `::archmage::` in the consumer's extern prelude.
 ///
-/// For **trait/generic bounds** (e.g., `impl HasX64V2`, `T: HasNeon`): falls
-/// back to checking `SimdToken` (sealed trait), which catches shadowing but
-/// cannot catch cross-trait aliasing.
+/// This catches:
+/// - **Shadowing:** local `struct X64V3Token` has no `__ARCHMAGE_TIER_TAG` const.
+/// - **Aliasing:** `use archmage::X64V2Token as X64V3Token` has the wrong tag.
 ///
-/// Both forms are zero-cost: the generated code is optimized away entirely.
+/// For **trait/generic bounds** (e.g., `impl HasX64V2`, `T: HasNeon`): no
+/// assertion needed — the sealed `SimdToken` trait already prevents forgery.
+///
+/// Both forms are zero-cost: `const` assertions vanish from the binary.
 fn gen_token_assertion(
     token_type_name: &Option<String>,
-    token_ident: &Ident,
+    token_type: &Option<Type>,
 ) -> proc_macro2::TokenStream {
-    if let Some(name) = token_type_name {
-        // Concrete token: verify the exact type via fully-qualified path.
-        // This catches both shadowing (non-archmage type) and aliasing
-        // (wrong archmage token renamed to match this name).
-        let expected_type = format_ident!("{}", name);
-        quote! {
-            // Compile-time proof that the token is genuinely ::archmage::#expected_type.
-            // Catches name shadowing (local struct) and aliasing (wrong token renamed).
-            {
-                fn __archmage_verify(_: &::archmage::#expected_type) {}
-                __archmage_verify(&#token_ident);
-            }
-        }
-    } else {
-        // Trait/generic bound: can only verify SimdToken (sealed).
-        quote! {
-            ::archmage::__private::assert_archmage_token(&#token_ident);
-        }
+    if let (Some(name), Some(ty)) = (token_type_name, token_type)
+        && let Some(expected_tag) = crate::generated::expected_tier_tag(name)
+    {
+        // Use array-indexing trick instead of assert!() to avoid
+        // ::core::panicking::panic (unstable) in macro-expanded output.
+        // When the condition is true:  [()][!true as usize]  = [()][0] = ()  (ok)
+        // When the condition is false: [()][!false as usize] = [()][1]        (compile error)
+        return quote! {
+            // Compile-time proof that the token type is genuinely the expected
+            // archmage type. Catches shadowing (no tag) and aliasing (wrong tag).
+            const _: () = [()][!(<#ty>::__ARCHMAGE_TIER_TAG == #expected_tag) as usize];
+        };
     }
+    // Trait/generic bound or unknown token: the sealed SimdToken trait
+    // prevents forgery. No path-based assertion needed.
+    quote! {}
 }
 
 #[derive(Default)]
@@ -180,6 +182,7 @@ pub(crate) fn arcane_impl(
         target_arch,
         token_type_name,
         magetypes_namespace,
+        token_type,
     } = match find_token_param(&input_fn.sig) {
         Some(result) => result,
         None => {
@@ -338,6 +341,7 @@ pub(crate) fn arcane_impl(
             &args,
             target_arch,
             token_type_name,
+            token_type,
             target_feature_attrs,
             inline_attr,
             _token_ident,
@@ -348,6 +352,7 @@ pub(crate) fn arcane_impl(
             &args,
             target_arch,
             token_type_name,
+            token_type,
             target_feature_attrs,
             inline_attr,
             _token_ident,
@@ -469,14 +474,16 @@ pub(crate) fn arcane_impl_wasm_safe(
 /// lacks matching target features. Compatible with `#![forbid(unsafe_code)]`.
 ///
 /// Self/self work naturally since both functions live in the same impl scope.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn arcane_impl_sibling(
     input_fn: LightFn,
     args: &ArcaneArgs,
     target_arch: Option<&str>,
     token_type_name: Option<String>,
+    token_type: Option<Type>,
     target_feature_attrs: Vec<Attribute>,
     inline_attr: Attribute,
-    token_ident: Ident,
+    _token_ident: Ident,
 ) -> TokenStream {
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
@@ -583,7 +590,7 @@ pub(crate) fn arcane_impl_sibling(
         // Wrapper function: fn original_name(...) { unsafe { sibling_call } }
         // The unsafe block is needed because the sibling has #[target_feature] and
         // the wrapper doesn't — calling across this boundary requires unsafe.
-        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
+        let token_assertion = gen_token_assertion(&token_type_name, &token_type);
         let wrapper_fn = quote! {
             #cfg_guard
             #(#attrs)*
@@ -671,14 +678,16 @@ pub(crate) fn arcane_impl_sibling(
 /// This is the original approach: generates a nested inner function inside the
 /// original function. Required when `_self = Type` is used because Self must be
 /// replaced in the nested function (where it's not in scope).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn arcane_impl_nested(
     input_fn: LightFn,
     args: &ArcaneArgs,
     target_arch: Option<&str>,
     token_type_name: Option<String>,
+    token_type: Option<Type>,
     target_feature_attrs: Vec<Attribute>,
     inline_attr: Attribute,
-    token_ident: Ident,
+    _token_ident: Ident,
 ) -> TokenStream {
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
@@ -811,7 +820,7 @@ pub(crate) fn arcane_impl_nested(
             quote! {}
         };
 
-        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
+        let token_assertion = gen_token_assertion(&token_type_name, &token_type);
         quote! {
             // Real implementation for the correct architecture
             #cfg_guard
@@ -834,7 +843,7 @@ pub(crate) fn arcane_impl_nested(
         }
     } else {
         // No specific arch (trait bounds or generic) - generate without cfg guards
-        let token_assertion = gen_token_assertion(&token_type_name, &token_ident);
+        let token_assertion = gen_token_assertion(&token_type_name, &token_type);
         quote! {
             #(#attrs)*
             #[inline(always)]

--- a/archmage-macros/src/generated/registry.rs
+++ b/archmage-macros/src/generated/registry.rs
@@ -603,6 +603,33 @@ pub(crate) fn can_downgrade_tier(from_suffix: &str, to_suffix: &str) -> bool {
     )
 }
 
+/// Returns the expected tier tag for a concrete token type name.
+///
+/// Used by `#[arcane]` to emit compile-time assertions.
+/// Generated from token-registry.toml.
+pub(crate) fn expected_tier_tag(token_name: &str) -> Option<u32> {
+    match token_name {
+        "ScalarToken" => Some(0xD141EACA),
+        "X64V1Token" | "Sse2Token" => Some(0x510E0DCD),
+        "X64V2Token" => Some(0x8CCD97C6),
+        "X64CryptoToken" => Some(0xF5F0FBF5),
+        "X64V3Token" | "Desktop64" | "Avx2FmaToken" => Some(0xF38B284B),
+        "X64V3CryptoToken" => Some(0x01EAE708),
+        "X64V4Token" | "Avx512Token" | "Server64" => Some(0xFE1B900C),
+        "X64V4xToken" | "Avx512ModernToken" => Some(0x8F63232A),
+        "Avx512Fp16Token" => Some(0x2F39FFC0),
+        "NeonToken" | "Arm64" => Some(0x72CB52B2),
+        "NeonAesToken" => Some(0x8C16863D),
+        "NeonSha3Token" => Some(0x8215198F),
+        "NeonCrcToken" => Some(0x5C2B1B4E),
+        "Arm64V2Token" => Some(0xB0231590),
+        "Arm64V3Token" => Some(0xB2F6E2D5),
+        "Wasm128Token" => Some(0x1E0DF26B),
+        "Wasm128RelaxedToken" => Some(0x821D5452),
+        _ => None,
+    }
+}
+
 /// All concrete token names that exist in the runtime crate.
 #[cfg(test)]
 pub(crate) const ALL_CONCRETE_TOKENS: &[&str] = &[

--- a/archmage-macros/src/rite.rs
+++ b/archmage-macros/src/rite.rs
@@ -102,6 +102,7 @@ pub(crate) fn rite_single_impl(mut input_fn: LightFn, args: RiteArgs) -> TokenSt
         target_arch,
         token_type_name: _token_type_name,
         magetypes_namespace,
+        token_type: _,
     } = if let Some(tier_token) = args.tier_tokens.first() {
         // Tier specified directly (e.g., #[rite(v3)]) — no token param needed
         let features = token_to_features(tier_token)
@@ -115,6 +116,7 @@ pub(crate) fn rite_single_impl(mut input_fn: LightFn, args: RiteArgs) -> TokenSt
             target_arch,
             token_type_name: Some(tier_token.clone()),
             magetypes_namespace,
+            token_type: None,
         }
     } else {
         match find_token_param(&input_fn.sig) {

--- a/archmage-macros/src/token_discovery.rs
+++ b/archmage-macros/src/token_discovery.rs
@@ -190,6 +190,9 @@ pub(crate) struct TokenParamInfo {
     pub token_type_name: Option<String>,
     /// Magetypes width namespace (e.g., "v3", "neon", "wasm128")
     pub magetypes_namespace: Option<&'static str>,
+    /// Full type from the function signature (for const tier tag assertion).
+    /// Set for concrete token types, None for trait/generic bounds.
+    pub token_type: Option<Type>,
 }
 
 /// Resolve magetypes namespace from a list of trait names.
@@ -227,17 +230,21 @@ pub(crate) fn find_token_param(sig: &Signature) -> Option<TokenParamInfo> {
             }
             FnArg::Typed(PatType { pat, ty, .. }) => {
                 if let Some(info) = extract_token_type_info(ty) {
-                    let (features, arch, token_name, mage_ns) = match info {
+                    let (features, arch, token_name, mage_ns, full_type) = match info {
                         TokenTypeInfo::Concrete(ref name) => {
                             let features = token_to_features(name).map(|f| f.to_vec());
                             let arch = token_to_arch(name);
                             let ns = token_to_magetypes_namespace(name);
-                            (features, arch, Some(name.clone()), ns)
+                            // Clone the full Type for const tier tag assertion.
+                            // This preserves any path prefix (e.g., `my_crate::X64V3Token`)
+                            // so the assertion resolves through re-exports.
+                            let full_type = Some(ty.as_ref().clone());
+                            (features, arch, Some(name.clone()), ns, full_type)
                         }
                         TokenTypeInfo::ImplTrait(ref trait_names) => {
                             let ns = traits_to_magetypes_namespace(trait_names);
                             let arch = traits_to_arch(trait_names);
-                            (traits_to_features(trait_names), arch, None, ns)
+                            (traits_to_features(trait_names), arch, None, ns, None)
                         }
                         TokenTypeInfo::Generic(type_name) => {
                             // Look up the generic parameter's bounds
@@ -247,7 +254,7 @@ pub(crate) fn find_token_param(sig: &Signature) -> Option<TokenParamInfo> {
                                 .as_ref()
                                 .and_then(|t| traits_to_magetypes_namespace(t));
                             let arch = bounds.as_ref().and_then(|t| traits_to_arch(t));
-                            (features, arch, None, ns)
+                            (features, arch, None, ns, None)
                         }
                     };
 
@@ -267,6 +274,7 @@ pub(crate) fn find_token_param(sig: &Signature) -> Option<TokenParamInfo> {
                                 target_arch: arch,
                                 token_type_name: token_name,
                                 magetypes_namespace: mage_ns,
+                                token_type: full_type,
                             });
                         }
                     }

--- a/src/tokens/generated/arm.rs
+++ b/src/tokens/generated/arm.rs
@@ -1391,6 +1391,36 @@ fn arm64_v3_detect() -> Option<Arm64V3Token> {
 /// Type alias for [`NeonToken`].
 pub type Arm64 = NeonToken;
 
+impl NeonToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x72CB52B2;
+}
+
+impl NeonAesToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8C16863D;
+}
+
+impl NeonSha3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8215198F;
+}
+
+impl NeonCrcToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x5C2B1B4E;
+}
+
+impl Arm64V2Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xB0231590;
+}
+
+impl Arm64V3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xB2F6E2D5;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for NeonToken {}
 #[allow(deprecated)]

--- a/src/tokens/generated/arm_stubs.rs
+++ b/src/tokens/generated/arm_stubs.rs
@@ -410,6 +410,36 @@ impl Arm64V3Token {
 /// Type alias for [`NeonToken`].
 pub type Arm64 = NeonToken;
 
+impl NeonToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x72CB52B2;
+}
+
+impl NeonAesToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8C16863D;
+}
+
+impl NeonSha3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8215198F;
+}
+
+impl NeonCrcToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x5C2B1B4E;
+}
+
+impl Arm64V2Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xB0231590;
+}
+
+impl Arm64V3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xB2F6E2D5;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for NeonToken {}
 #[allow(deprecated)]

--- a/src/tokens/generated/wasm.rs
+++ b/src/tokens/generated/wasm.rs
@@ -192,6 +192,16 @@ impl Wasm128RelaxedToken {
     }
 }
 
+impl Wasm128Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x1E0DF26B;
+}
+
+impl Wasm128RelaxedToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x821D5452;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for Wasm128Token {}
 #[allow(deprecated)]

--- a/src/tokens/generated/wasm_stubs.rs
+++ b/src/tokens/generated/wasm_stubs.rs
@@ -138,6 +138,16 @@ impl Wasm128RelaxedToken {
     }
 }
 
+impl Wasm128Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x1E0DF26B;
+}
+
+impl Wasm128RelaxedToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x821D5452;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for Wasm128Token {}
 #[allow(deprecated)]

--- a/src/tokens/generated/x86.rs
+++ b/src/tokens/generated/x86.rs
@@ -2955,6 +2955,46 @@ pub type Server64 = X64V4Token;
 /// Type alias for [`X64V4xToken`].
 pub type Avx512ModernToken = X64V4xToken;
 
+impl X64V1Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x510E0DCD;
+}
+
+impl X64V2Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8CCD97C6;
+}
+
+impl X64CryptoToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xF5F0FBF5;
+}
+
+impl X64V3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xF38B284B;
+}
+
+impl X64V3CryptoToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x01EAE708;
+}
+
+impl X64V4Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xFE1B900C;
+}
+
+impl X64V4xToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8F63232A;
+}
+
+impl Avx512Fp16Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x2F39FFC0;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for X64V1Token {}
 #[allow(deprecated)]

--- a/src/tokens/generated/x86_stubs.rs
+++ b/src/tokens/generated/x86_stubs.rs
@@ -563,6 +563,46 @@ pub type Server64 = X64V4Token;
 /// Type alias for [`X64V4xToken`].
 pub type Avx512ModernToken = X64V4xToken;
 
+impl X64V1Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x510E0DCD;
+}
+
+impl X64V2Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8CCD97C6;
+}
+
+impl X64CryptoToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xF5F0FBF5;
+}
+
+impl X64V3Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xF38B284B;
+}
+
+impl X64V3CryptoToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x01EAE708;
+}
+
+impl X64V4Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xFE1B900C;
+}
+
+impl X64V4xToken {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x8F63232A;
+}
+
+impl Avx512Fp16Token {
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0x2F39FFC0;
+}
+
 #[allow(deprecated)]
 impl Has128BitSimd for X64V1Token {}
 #[allow(deprecated)]

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -255,6 +255,16 @@ impl ScalarToken {
 }
 
 impl ScalarToken {
+    /// Tier tag for compile-time token identity assertion.
+    ///
+    /// Used by `#[arcane]` to verify that a `ScalarToken` parameter is genuinely
+    /// `archmage::ScalarToken` and not a shadowed or aliased type.
+    /// Must match `expected_tier_tag("ScalarToken")` in the proc-macro registry.
+    #[doc(hidden)]
+    pub const __ARCHMAGE_TIER_TAG: u32 = 0xD141EACA;
+}
+
+impl ScalarToken {
     /// Scalar tokens cannot be disabled (they are always available).
     ///
     /// Always returns `Err(CompileTimeGuaranteedError)` because `ScalarToken`

--- a/tests/compile_fail/token_aliasing.stderr
+++ b/tests/compile_fail/token_aliasing.stderr
@@ -1,19 +1,9 @@
-error[E0308]: mismatched types
+error[E0080]: index out of bounds: the length is 1 but the index is 1
  --> tests/compile_fail/token_aliasing.rs:8:1
   |
 8 | #[arcane]
-  | ^^^^^^^^^
-  | |
-  | expected `&X64V3Token`, found `&X64V2Token`
-  | arguments to this function are incorrect
+  | ^^^^^^^^^ evaluation of `evil::_` failed here
   |
-  = note: expected reference `&X64V3Token`
-             found reference `&X64V2Token`
-note: function defined here
- --> tests/compile_fail/token_aliasing.rs:8:1
-  |
-8 | #[arcane]
-  | ^^^^^^^^^
   = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unused variable: `token`

--- a/tests/compile_fail/token_shadowing.stderr
+++ b/tests/compile_fail/token_shadowing.stderr
@@ -1,26 +1,10 @@
-error[E0308]: mismatched types
+error[E0599]: no associated item named `__ARCHMAGE_TIER_TAG` found for struct `X64V3Token` in the current scope
   --> tests/compile_fail/token_shadowing.rs:11:1
-   |
-11 | #[arcane]
-   | ^^^^^^^^^
-   | |
-   | expected `archmage::X64V3Token`, found `X64V3Token`
-   | arguments to this function are incorrect
-   |
-   = note: `X64V3Token` and `archmage::X64V3Token` have similar names, but are actually distinct types
-note: `X64V3Token` is defined in the current crate
-  --> tests/compile_fail/token_shadowing.rs:9:1
    |
  9 | struct X64V3Token;
-   | ^^^^^^^^^^^^^^^^^
-note: `archmage::X64V3Token` is defined in crate `archmage`
-  --> src/tokens/generated/x86.rs
-   |
-   | pub struct X64V3Token {
-   | ^^^^^^^^^^^^^^^^^^^^^
-note: function defined here
-  --> tests/compile_fail/token_shadowing.rs:11:1
-   |
+   | ----------------- associated item `__ARCHMAGE_TIER_TAG` not found for this struct
+10 |
 11 | #[arcane]
-   | ^^^^^^^^^
+   | ^^^^^^^^^ associated item not found in `X64V3Token`
+   |
    = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/expand/arcane/associated_type_bound.expanded.rs
+++ b/tests/expand/arcane/associated_type_bound.expanded.rs
@@ -16,10 +16,7 @@ fn sum_iter<I>(token: X64V3Token, iter: I) -> f32
 where
     I: Iterator<Item = f32>,
 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_iter::<I>(token, iter) }
 }
 fn main() {}

--- a/tests/expand/arcane/box_dyn_return.expanded.rs
+++ b/tests/expand/arcane/box_dyn_return.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_make_adder(token: X64V3Token, offset: f32) -> Box<dyn Fn(f32) -> f32
 }
 #[inline(always)]
 fn make_adder(token: X64V3Token, offset: f32) -> Box<dyn Fn(f32) -> f32> {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_make_adder(token, offset) }
 }
 fn main() {}

--- a/tests/expand/arcane/closure_param.expanded.rs
+++ b/tests/expand/arcane/closure_param.expanded.rs
@@ -14,10 +14,7 @@ fn __arcane_apply(
 }
 #[inline(always)]
 fn apply(token: X64V3Token, data: &[f32; 4], f: impl Fn(f32) -> f32) -> [f32; 4] {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_apply(token, data, f) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_array.expanded.rs
+++ b/tests/expand/arcane/destructured_array.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: [f32; 4]) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: [f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_nested.expanded.rs
+++ b/tests/expand/arcane/destructured_nested.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: ((f32, f32), f32)) -> f
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: ((f32, f32), f32)) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/destructured_tuple.expanded.rs
+++ b/tests/expand/arcane/destructured_tuple.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(token: X64V3Token, __archmage_arg_0: (f32, f32)) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, __archmage_arg_0: (f32, f32)) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, __archmage_arg_0) }
 }
 fn main() {}

--- a/tests/expand/arcane/dyn_trait_param.expanded.rs
+++ b/tests/expand/arcane/dyn_trait_param.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(token: X64V3Token, callback: &dyn Fn(f32) -> f32, x: f32) ->
 }
 #[inline(always)]
 fn process(token: X64V3Token, callback: &dyn Fn(f32) -> f32, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, callback, x) }
 }
 fn main() {}

--- a/tests/expand/arcane/fn_ptr_param.expanded.rs
+++ b/tests/expand/arcane/fn_ptr_param.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_apply_fn(token: X64V3Token, f: fn(f32) -> f32, x: f32) -> f32 {
 }
 #[inline(always)]
 fn apply_fn(token: X64V3Token, f: fn(f32) -> f32, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_apply_fn(token, f, x) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_const.expanded.rs
+++ b/tests/expand/arcane/generic_const.expanded.rs
@@ -14,10 +14,7 @@ fn __arcane_sum_n<const N: usize>(token: X64V3Token, data: &[f32; N]) -> f32 {
 }
 #[inline(always)]
 fn sum_n<const N: usize>(token: X64V3Token, data: &[f32; N]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_n::<N>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_lifetime.expanded.rs
+++ b/tests/expand/arcane/generic_lifetime.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process<'a>(token: X64V3Token, data: &'a [f32]) -> &'a f32 {
 }
 #[inline(always)]
 fn process<'a>(token: X64V3Token, data: &'a [f32]) -> &'a f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_lifetime_and_type.expanded.rs
+++ b/tests/expand/arcane/generic_lifetime_and_type.expanded.rs
@@ -13,10 +13,7 @@ fn __arcane_first_n<'a, T: Copy, const N: usize>(
 }
 #[inline(always)]
 fn first_n<'a, T: Copy, const N: usize>(token: X64V3Token, data: &'a [T; N]) -> &'a T {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_first_n::<T, N>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_multi_params.expanded.rs
+++ b/tests/expand/arcane/generic_multi_params.expanded.rs
@@ -11,10 +11,7 @@ fn __arcane_add_items<T: Add<Output = T> + Copy>(token: X64V3Token, a: T, b: T) 
 }
 #[inline(always)]
 fn add_items<T: Add<Output = T> + Copy>(token: X64V3Token, a: T, b: T) -> T {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_add_items::<T>(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/generic_where_clause.expanded.rs
+++ b/tests/expand/arcane/generic_where_clause.expanded.rs
@@ -20,10 +20,7 @@ fn sum_slice<T>(token: X64V3Token, data: &[T]) -> f32
 where
     T: Copy + Into<f32>,
 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_slice::<T>(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/higher_ranked_trait_bound.expanded.rs
+++ b/tests/expand/arcane/higher_ranked_trait_bound.expanded.rs
@@ -16,10 +16,7 @@ fn apply_ref<F>(token: X64V3Token, f: F, data: &[f32]) -> f32
 where
     F: for<'a> Fn(&'a [f32]) -> f32,
 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_apply_ref::<F>(token, f, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/import_intrinsics.expanded.rs
+++ b/tests/expand/arcane/import_intrinsics.expanded.rs
@@ -16,10 +16,7 @@ fn __arcane_process(token: X64V3Token, a: &[f32; 8], b: &[f32; 8]) -> [f32; 8] {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: &[f32; 8], b: &[f32; 8]) -> [f32; 8] {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/multi_bounds.expanded.rs
+++ b/tests/expand/arcane/multi_bounds.expanded.rs
@@ -17,10 +17,7 @@ fn fma<T>(token: X64V3Token, a: T, b: T, c: T) -> T
 where
     T: Copy + Mul<Output = T> + Add<Output = T>,
 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_fma::<T>(token, a, b, c) }
 }
 fn main() {}

--- a/tests/expand/arcane/multiple_wildcards.expanded.rs
+++ b/tests/expand/arcane/multiple_wildcards.expanded.rs
@@ -20,10 +20,7 @@ fn process(
     __archmage_arg_1: f32,
     __archmage_arg_2: f32,
 ) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&__archmage_arg_0);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(__archmage_arg_0, __archmage_arg_1, __archmage_arg_2) }
 }
 fn main() {}

--- a/tests/expand/arcane/nested.expanded.rs
+++ b/tests/expand/arcane/nested.expanded.rs
@@ -8,10 +8,7 @@ fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
     fn __simd_inner_process(token: X64V3Token, a: f32, b: f32) -> f32 {
         a + b
     }
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __simd_inner_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/nested_self.expanded.rs
+++ b/tests/expand/arcane/nested_self.expanded.rs
@@ -12,10 +12,9 @@ impl Processor {
         fn __simd_inner_process(_self: &Processor, token: X64V3Token, a: f32) -> f32 {
             _self.val + a
         }
-        {
-            fn __archmage_verify(_: &::archmage::X64V3Token) {}
-            __archmage_verify(&token);
-        }
+        const _: () = [
+            (),
+        ][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
         unsafe { __simd_inner_process(self, token, a) }
     }
 }

--- a/tests/expand/arcane/return_impl_trait.expanded.rs
+++ b/tests/expand/arcane/return_impl_trait.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_make_iter(token: X64V3Token, data: &[f32]) -> impl Iterator<Item = &
 }
 #[inline(always)]
 fn make_iter(token: X64V3Token, data: &[f32]) -> impl Iterator<Item = &f32> {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_make_iter(token, data) }
 }
 fn main() {}

--- a/tests/expand/arcane/sibling.expanded.rs
+++ b/tests/expand/arcane/sibling.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_process(token: X64V3Token, a: f32, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_first.expanded.rs
+++ b/tests/expand/arcane/token_first.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(token: X64V3Token, a: f32, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32, b: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_generic.expanded.rs
+++ b/tests/expand/arcane/token_generic.expanded.rs
@@ -7,7 +7,6 @@ fn __arcane_process<T: HasX64V2>(token: T, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process<T: HasX64V2>(token: T, a: f32) -> f32 {
-    ::archmage::__private::assert_archmage_token(&token);
     unsafe { __arcane_process::<T>(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_last.expanded.rs
+++ b/tests/expand/arcane/token_last.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(a: f32, b: f32, token: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn process(a: f32, b: f32, token: X64V3Token) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(a, b, token) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_middle.expanded.rs
+++ b/tests/expand/arcane/token_middle.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(a: f32, token: X64V3Token, b: f32) -> f32 {
 }
 #[inline(always)]
 fn process(a: f32, token: X64V3Token, b: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(a, token, b) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_trait_bound.expanded.rs
+++ b/tests/expand/arcane/token_trait_bound.expanded.rs
@@ -7,7 +7,6 @@ fn __arcane_process(token: impl HasX64V2, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: impl HasX64V2, a: f32) -> f32 {
-    ::archmage::__private::assert_archmage_token(&token);
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v2.expanded.rs
+++ b/tests/expand/arcane/token_v2.expanded.rs
@@ -7,10 +7,7 @@ fn __arcane_process(token: X64V2Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V2Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V2Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V2Token>::__ARCHMAGE_TIER_TAG == 2362283974u32) as usize];
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v3.expanded.rs
+++ b/tests/expand/arcane/token_v3.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/token_v4.expanded.rs
+++ b/tests/expand/arcane/token_v4.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_process(token: X64V4Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V4Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/arcane/unsafe_fn.expanded.rs
+++ b/tests/expand/arcane/unsafe_fn.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_process(token: X64V3Token, ptr: *const f32) -> f32 {
 }
 #[inline(always)]
 unsafe fn process(token: X64V3Token, ptr: *const f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, ptr) }
 }
 fn main() {}

--- a/tests/expand/arcane/wildcard_token.expanded.rs
+++ b/tests/expand/arcane/wildcard_token.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_process(__archmage_arg_0: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(__archmage_arg_0: X64V3Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&__archmage_arg_0);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(__archmage_arg_0, a) }
 }
 fn main() {}

--- a/tests/expand/autoversion/basic.expanded.rs
+++ b/tests/expand/autoversion/basic.expanded.rs
@@ -23,10 +23,9 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -41,10 +40,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/cfg_feature.expanded.rs
+++ b/tests/expand/autoversion/cfg_feature.expanded.rs
@@ -14,10 +14,9 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -32,10 +31,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/default_tier.expanded.rs
+++ b/tests/expand/autoversion/default_tier.expanded.rs
@@ -23,10 +23,9 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -41,10 +40,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_gated.expanded.rs
+++ b/tests/expand/autoversion/explicit_gated.expanded.rs
@@ -20,10 +20,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_v3_neon_scalar.expanded.rs
+++ b/tests/expand/autoversion/explicit_v3_neon_scalar.expanded.rs
@@ -20,10 +20,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/explicit_v3_scalar.expanded.rs
+++ b/tests/expand/autoversion/explicit_v3_scalar.expanded.rs
@@ -20,10 +20,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/plain_self.expanded.rs
+++ b/tests/expand/autoversion/plain_self.expanded.rs
@@ -27,10 +27,9 @@ impl P {
     #[allow(dead_code)]
     #[inline(always)]
     fn apply_v4(&self, _token: archmage::X64V4Token, x: f32) -> f32 {
-        {
-            fn __archmage_verify(_: &::archmage::X64V4Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
         unsafe { self.__arcane_apply_v4(_token, x) }
     }
     #[doc(hidden)]
@@ -45,10 +44,9 @@ impl P {
     #[allow(dead_code)]
     #[inline(always)]
     fn apply_v3(&self, _token: archmage::X64V3Token, x: f32) -> f32 {
-        {
-            fn __archmage_verify(_: &::archmage::X64V3Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
         unsafe { self.__arcane_apply_v3(_token, x) }
     }
     #[allow(dead_code)]

--- a/tests/expand/autoversion/scalar_token.expanded.rs
+++ b/tests/expand/autoversion/scalar_token.expanded.rs
@@ -23,10 +23,9 @@ fn __arcane_process_v4(token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v4(token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_process_v4(token, data) }
 }
 #[doc(hidden)]
@@ -41,10 +40,9 @@ fn __arcane_process_v3(token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v3(token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process_v3(token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/self_type.expanded.rs
+++ b/tests/expand/autoversion/self_type.expanded.rs
@@ -30,10 +30,9 @@ impl P {
         ) -> f32 {
             x * _self.f
         }
-        {
-            fn __archmage_verify(_: &::archmage::X64V4Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
         unsafe { __simd_inner_apply_v4(self, _token, x) }
     }
     #[allow(dead_code)]
@@ -51,10 +50,9 @@ impl P {
         ) -> f32 {
             x * _self.f
         }
-        {
-            fn __archmage_verify(_: &::archmage::X64V3Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
         unsafe { __simd_inner_apply_v3(self, _token, x) }
     }
     #[allow(dead_code)]

--- a/tests/expand/autoversion/tier_modifiers.expanded.rs
+++ b/tests/expand/autoversion/tier_modifiers.expanded.rs
@@ -23,10 +23,9 @@ fn __arcane_sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_sum_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -41,10 +40,9 @@ fn __arcane_sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn sum_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_sum_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/autoversion/unsafe_fn.expanded.rs
+++ b/tests/expand/autoversion/unsafe_fn.expanded.rs
@@ -31,10 +31,9 @@ fn __arcane_process_v4(
 #[allow(dead_code)]
 #[inline(always)]
 unsafe fn process_v4(_token: archmage::X64V4Token, ptr: *const f32, len: usize) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_process_v4(_token, ptr, len) }
 }
 #[doc(hidden)]
@@ -57,10 +56,9 @@ fn __arcane_process_v3(
 #[allow(dead_code)]
 #[inline(always)]
 unsafe fn process_v3(_token: archmage::X64V3Token, ptr: *const f32, len: usize) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process_v3(_token, ptr, len) }
 }
 #[allow(dead_code)]

--- a/tests/expand/combinations/arcane_calls_rite.expanded.rs
+++ b/tests/expand/combinations/arcane_calls_rite.expanded.rs
@@ -22,10 +22,7 @@ fn __arcane_process(token: X64V3Token, data: &[f32; 4]) -> [f32; 4] {
 }
 #[inline(always)]
 fn process(token: X64V3Token, data: &[f32; 4]) -> [f32; 4] {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, data) }
 }
 fn main() {}

--- a/tests/expand/combinations/autoversion_chain.expanded.rs
+++ b/tests/expand/combinations/autoversion_chain.expanded.rs
@@ -23,10 +23,9 @@ fn __arcane_inner_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn inner_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -41,10 +40,9 @@ fn __arcane_inner_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn inner_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_token, data) }
 }
 #[allow(dead_code)]
@@ -75,10 +73,9 @@ fn __arcane_outer_v4(_token: archmage::X64V4Token, data: &[f32; 4], scale: f32) 
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v4(_token: archmage::X64V4Token, data: &[f32; 4], scale: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_outer_v4(_token, data, scale) }
 }
 #[doc(hidden)]
@@ -93,10 +90,9 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, data: &[f32; 4], scale: f32) 
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, data: &[f32; 4], scale: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer_v3(_token, data, scale) }
 }
 #[allow(dead_code)]

--- a/tests/expand/combinations/token_downgrade.expanded.rs
+++ b/tests/expand/combinations/token_downgrade.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_v3_helper(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v3_helper(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_v3_helper(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_v4_caller(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v4_caller(token: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_v4_caller(token, x) }
 }
 fn main() {}

--- a/tests/expand/combinations/token_upgrade.expanded.rs
+++ b/tests/expand/combinations/token_upgrade.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_v4_fast(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v4_fast(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_v4_fast(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_v3_with_upgrade(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn v3_with_upgrade(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_v3_with_upgrade(_t, x) }
 }
 fn main() {}

--- a/tests/expand/deprecated/autoversion_simdtoken.expanded.rs
+++ b/tests/expand/deprecated/autoversion_simdtoken.expanded.rs
@@ -33,10 +33,9 @@ fn __arcane_process_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v4(_token: archmage::X64V4Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_process_v4(_token, data) }
 }
 #[doc(hidden)]
@@ -51,10 +50,9 @@ fn __arcane_process_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn process_v3(_token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process_v3(_token, data) }
 }
 #[allow(dead_code)]

--- a/tests/expand/deprecated/dispatch_variant.expanded.rs
+++ b/tests/expand/deprecated/dispatch_variant.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_compute_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn compute_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_compute_v3(_t, x) }
 }
 fn compute_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/deprecated/simd_fn.expanded.rs
+++ b/tests/expand/deprecated/simd_fn.expanded.rs
@@ -12,10 +12,7 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 #[allow(deprecated)]
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/deprecated/simd_route.expanded.rs
+++ b/tests/expand/deprecated/simd_route.expanded.rs
@@ -10,10 +10,7 @@ fn __arcane_compute_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn compute_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_compute_v3(_t, x) }
 }
 fn compute_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/deprecated/token_target_features_boundary.expanded.rs
+++ b/tests/expand/deprecated/token_target_features_boundary.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_process(token: X64V3Token, a: f32) -> f32 {
 }
 #[inline(always)]
 fn process(token: X64V3Token, a: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_process(token, a) }
 }
 fn main() {}

--- a/tests/expand/incant/default_tiers.expanded.rs
+++ b/tests/expand/incant/default_tiers.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/feature_gated.expanded.rs
+++ b/tests/expand/incant/feature_gated.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/tier_modifiers.expanded.rs
+++ b/tests/expand/incant/tier_modifiers.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/token_explicit_first.expanded.rs
+++ b/tests/expand/incant/token_explicit_first.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/incant/token_explicit_last.expanded.rs
+++ b/tests/expand/incant/token_explicit_last.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(x: f32, _t: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(x: f32, _t: X64V3Token) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(x, _t) }
 }
 fn inner_scalar(x: f32, _t: ScalarToken) -> f32 {

--- a/tests/expand/incant/token_prepend.expanded.rs
+++ b/tests/expand/incant/token_prepend.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/arcane_downgrade.expanded.rs
+++ b/tests/expand/rewrite/arcane_downgrade.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -44,10 +38,7 @@ fn __arcane_outer(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_exact.expanded.rs
+++ b/tests/expand/rewrite/arcane_exact.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -44,10 +38,7 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_named_token.expanded.rs
+++ b/tests/expand/rewrite/arcane_named_token.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -28,10 +25,7 @@ fn __arcane_outer(alligator: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(alligator: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&alligator);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(alligator, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_token_last.expanded.rs
+++ b/tests/expand/rewrite/arcane_token_last.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(x: f32, _t: X64V3Token) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(x: f32, _t: X64V3Token) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(x, _t) }
 }
 fn inner_scalar(x: f32, _t: ScalarToken) -> f32 {
@@ -28,10 +25,7 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_upgrade.expanded.rs
+++ b/tests/expand/rewrite/arcane_upgrade.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -47,10 +41,7 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/arcane_upgrade_gated.expanded.rs
+++ b/tests/expand/rewrite/arcane_upgrade_gated.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -47,10 +41,7 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/autoversion_exact.expanded.rs
+++ b/tests/expand/rewrite/autoversion_exact.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -55,10 +49,9 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/autoversion_upgrade.expanded.rs
+++ b/tests/expand/rewrite/autoversion_upgrade.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -58,10 +52,9 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/autoversion_upgrade_gated.expanded.rs
+++ b/tests/expand/rewrite/autoversion_upgrade_gated.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v4(_t: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v4(_t: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_inner_v4(_t, x) }
 }
 #[doc(hidden)]
@@ -25,10 +22,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -58,10 +52,9 @@ fn __arcane_outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
 #[allow(dead_code)]
 #[inline(always)]
 fn outer_v3(_token: archmage::X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [
+        (),
+    ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer_v3(_token, x) }
 }
 #[allow(dead_code)]

--- a/tests/expand/rewrite/cross_branch_no_downgrade.expanded.rs
+++ b/tests/expand/rewrite/cross_branch_no_downgrade.expanded.rs
@@ -9,10 +9,9 @@ fn __arcane_inner_v3_crypto(_t: X64V3CryptoToken, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3_crypto(_t: X64V3CryptoToken, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3CryptoToken) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [
+        (),
+    ][!(<X64V3CryptoToken>::__ARCHMAGE_TIER_TAG == 32171784u32) as usize];
     unsafe { __arcane_inner_v3_crypto(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {
@@ -34,10 +33,7 @@ fn __arcane_outer(token: X64V4Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V4Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V4Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/rewrite/rite_exact.expanded.rs
+++ b/tests/expand/rewrite/rite_exact.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/rite_multi.expanded.rs
+++ b/tests/expand/rewrite/rite_multi.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/rite_tokenless_passthrough.expanded.rs
+++ b/tests/expand/rewrite/rite_tokenless_passthrough.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(_t: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_t: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_t);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_t, x) }
 }
 fn inner_scalar(_t: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/rewrite/scalar_fallback.expanded.rs
+++ b/tests/expand/rewrite/scalar_fallback.expanded.rs
@@ -12,10 +12,7 @@ fn __arcane_outer(token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn outer(token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_outer(token, x) }
 }
 fn main() {}

--- a/tests/expand/should-fail/autoversion_trait_impl.expanded.rs
+++ b/tests/expand/should-fail/autoversion_trait_impl.expanded.rs
@@ -39,10 +39,9 @@ impl Process for Filter {
             }
             sum
         }
-        {
-            fn __archmage_verify(_: &::archmage::X64V4Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V4Token>::__ARCHMAGE_TIER_TAG == 4263219212u32) as usize];
         unsafe { __simd_inner_process_v4(self, _token, data) }
     }
     #[allow(dead_code)]
@@ -66,10 +65,9 @@ impl Process for Filter {
             }
             sum
         }
-        {
-            fn __archmage_verify(_: &::archmage::X64V3Token) {}
-            __archmage_verify(&_token);
-        }
+        const _: () = [
+            (),
+        ][!(<archmage::X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
         unsafe { __simd_inner_process_v3(self, _token, data) }
     }
     #[allow(dead_code)]

--- a/tests/expand/should-fail/autoversion_trait_impl.expanded.stderr
+++ b/tests/expand/should-fail/autoversion_trait_impl.expanded.stderr
@@ -9,35 +9,35 @@ error[E0407]: method `process_v4` is not a member of trait `Process`
 25 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe,pclmulqdq,aes,av...
 26 | |         )]
 ...  |
-46 | |         unsafe { __simd_inner_process_v4(self, _token, data) }
-47 | |     }
+45 | |         unsafe { __simd_inner_process_v4(self, _token, data) }
+46 | |     }
    | |_____^ not a member of trait `Process`
 
 error[E0407]: method `process_v3` is not a member of trait `Process`
-  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:50:5
+  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:49:5
    |
-50 |       fn process_v3(&self, _token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
+49 |       fn process_v3(&self, _token: archmage::X64V3Token, data: &[f32; 4]) -> f32 {
    |       ^  ---------- help: there is an associated function with a similar name: `process`
    |  _____|
    | |
-51 | |         #[target_feature(
-52 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe"
-53 | |         )]
+50 | |         #[target_feature(
+51 | |             enable = "sse,sse2,sse3,ssse3,sse4.1,sse4.2,popcnt,cmpxchg16b,avx,avx2,fma,bmi1,bmi2,f16c,lzcnt,movbe"
+52 | |         )]
 ...  |
-73 | |         unsafe { __simd_inner_process_v3(self, _token, data) }
-74 | |     }
+71 | |         unsafe { __simd_inner_process_v3(self, _token, data) }
+72 | |     }
    | |_____^ not a member of trait `Process`
 
 error[E0407]: method `process_scalar` is not a member of trait `Process`
-  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:76:5
+  --> tests/expand/should-fail/autoversion_trait_impl.expanded.rs:74:5
    |
-76 | /     fn process_scalar(&self, _token: archmage::ScalarToken, data: &[f32; 4]) -> f32 {
-77 | |         let _self = self;
-78 | |         let mut sum = 0.0f32;
-79 | |         for &x in data {
+74 | /     fn process_scalar(&self, _token: archmage::ScalarToken, data: &[f32; 4]) -> f32 {
+75 | |         let _self = self;
+76 | |         let mut sum = 0.0f32;
+77 | |         for &x in data {
 ...  |
-84 | |         sum
-85 | |     }
+82 | |         sum
+83 | |     }
    | |_____^ not a member of trait `Process`
 
 warning: unused import: `archmage::autoversion`

--- a/tests/expand/should-fail/incant_passthrough.expanded.rs
+++ b/tests/expand/should-fail/incant_passthrough.expanded.rs
@@ -9,10 +9,7 @@ fn __arcane_inner_v3(_token: X64V3Token, x: f32) -> f32 {
 }
 #[inline(always)]
 fn inner_v3(_token: X64V3Token, x: f32) -> f32 {
-    {
-        fn __archmage_verify(_: &::archmage::X64V3Token) {}
-        __archmage_verify(&_token);
-    }
+    const _: () = [()][!(<X64V3Token>::__ARCHMAGE_TIER_TAG == 4085983307u32) as usize];
     unsafe { __arcane_inner_v3(_token, x) }
 }
 fn inner_scalar(_token: ScalarToken, x: f32) -> f32 {

--- a/tests/expand/should-fail/incant_passthrough.expanded.stderr
+++ b/tests/expand/should-fail/incant_passthrough.expanded.stderr
@@ -7,13 +7,13 @@ warning: unused imports: `NeonToken`, `arcane`, and `incant`
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
 
 error[E0658]: use of unstable library feature `panic_internals`: internal details of the implementation of the `panic!` and related macros
-  --> tests/expand/should-fail/incant_passthrough.expanded.rs:34:13
+  --> tests/expand/should-fail/incant_passthrough.expanded.rs:31:13
    |
-34 |             ::core::panicking::panic_fmt(
+31 |             ::core::panicking::panic_fmt(
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused import: `archmage::IntoConcreteToken`
-  --> tests/expand/should-fail/incant_passthrough.expanded.rs:23:13
+  --> tests/expand/should-fail/incant_passthrough.expanded.rs:20:13
    |
-23 |         use archmage::IntoConcreteToken;
+20 |         use archmage::IntoConcreteToken;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/soundness/token_aliasing_exploit.stderr
+++ b/tests/soundness/token_aliasing_exploit.stderr
@@ -1,19 +1,9 @@
-error[E0308]: mismatched types
+error[E0080]: index out of bounds: the length is 1 but the index is 1
   --> tests/soundness/token_aliasing_exploit.rs:15:1
    |
 15 | #[arcane]
-   | ^^^^^^^^^
-   | |
-   | expected `&X64V3Token`, found `&X64V2Token`
-   | arguments to this function are incorrect
+   | ^^^^^^^^^ evaluation of `evil::_` failed here
    |
-   = note: expected reference `&X64V3Token`
-              found reference `&X64V2Token`
-note: function defined here
-  --> tests/soundness/token_aliasing_exploit.rs:15:1
-   |
-15 | #[arcane]
-   | ^^^^^^^^^
    = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unused variable: `token`

--- a/tests/soundness/token_shadowing_exploit.stderr
+++ b/tests/soundness/token_shadowing_exploit.stderr
@@ -1,26 +1,10 @@
-error[E0308]: mismatched types
+error[E0599]: no associated item named `__ARCHMAGE_TIER_TAG` found for struct `X64V3Token` in the current scope
   --> tests/soundness/token_shadowing_exploit.rs:18:1
-   |
-18 | #[arcane]
-   | ^^^^^^^^^
-   | |
-   | expected `archmage::X64V3Token`, found `X64V3Token`
-   | arguments to this function are incorrect
-   |
-   = note: `X64V3Token` and `archmage::X64V3Token` have similar names, but are actually distinct types
-note: `X64V3Token` is defined in the current crate
-  --> tests/soundness/token_shadowing_exploit.rs:16:1
    |
 16 | struct X64V3Token;
-   | ^^^^^^^^^^^^^^^^^
-note: `archmage::X64V3Token` is defined in crate `archmage`
-  --> src/tokens/generated/x86.rs
-   |
-   | pub struct X64V3Token {
-   | ^^^^^^^^^^^^^^^^^^^^^
-note: function defined here
-  --> tests/soundness/token_shadowing_exploit.rs:18:1
-   |
+   | ----------------- associated item `__ARCHMAGE_TIER_TAG` not found for this struct
+17 |
 18 | #[arcane]
-   | ^^^^^^^^^
+   | ^^^^^^^^^ associated item not found in `X64V3Token`
+   |
    = note: this error originates in the attribute macro `arcane` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1515,7 +1515,19 @@ fn generate_all() -> Result<()> {
     println!("=== Generating Macro Registry ===");
     let registry_path = PathBuf::from("token-registry.toml");
     let reg = registry::Registry::load(&registry_path)?;
-    let generated = reg.generate_macro_registry();
+
+    // Parse major version from workspace Cargo.toml for tier tag hashing
+    let cargo_toml = fs::read_to_string("Cargo.toml")?;
+    let major_version: u32 = cargo_toml
+        .lines()
+        .find(|l| l.starts_with("version") || l.contains("version ="))
+        .and_then(|l| l.split('"').nth(1))
+        .and_then(|v| v.split('.').next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    println!("  Major version for tier tags: {major_version}");
+
+    let generated = reg.generate_macro_registry(major_version);
     let gen_dir = PathBuf::from("archmage-macros/src/generated");
     fs::create_dir_all(&gen_dir)?;
     let gen_path = gen_dir.join("registry.rs");
@@ -1557,7 +1569,7 @@ pub(crate) use registry::*;
     println!("\n=== Generating Token Implementations ===");
     let token_dir = PathBuf::from("src/tokens/generated");
     fs::create_dir_all(&token_dir)?;
-    let token_files = token_gen::generate_token_files(&reg);
+    let token_files = token_gen::generate_token_files(&reg, major_version);
     let mut token_total_bytes = 0;
     for (rel_path, content) in &token_files {
         let full_path = token_dir.join(rel_path);

--- a/xtask/src/registry.rs
+++ b/xtask/src/registry.rs
@@ -436,6 +436,24 @@ impl std::fmt::Display for Registry {
 }
 
 // ============================================================================
+// Tier Tags
+// ============================================================================
+
+/// FNV-1a hash of token name seeded with major version.
+///
+/// Produces a unique tag for each token struct name, used for compile-time
+/// assertion that a concrete token type is genuinely the expected archmage
+/// type (not shadowed or aliased).
+pub fn tier_tag(token_name: &str, major_version: u32) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5 ^ major_version.wrapping_mul(0x0100_0193);
+    for byte in token_name.bytes() {
+        hash ^= byte as u32;
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}
+
+// ============================================================================
 // Code Generation
 // ============================================================================
 
@@ -447,7 +465,7 @@ impl Registry {
     /// - `trait_to_features()` — maps trait and token names to feature lists (for bounds)
     /// - `ALL_CONCRETE_TOKENS` — all token names including aliases
     /// - `ALL_TRAIT_NAMES` — all trait names
-    pub fn generate_macro_registry(&self) -> String {
+    pub fn generate_macro_registry(&self, major_version: u32) -> String {
         use indoc::formatdoc;
         let mut out = String::with_capacity(8192);
 
@@ -475,6 +493,8 @@ impl Registry {
         self.gen_canonical_token_to_tier_suffix(&mut out);
         out.push('\n');
         self.gen_can_downgrade_tier(&mut out);
+        out.push('\n');
+        self.gen_expected_tier_tag(&mut out, major_version);
         out.push('\n');
         self.gen_all_concrete_tokens(&mut out);
         out.push('\n');
@@ -790,6 +810,38 @@ impl Registry {
         out.push_str("\n    )\n}\n");
     }
 
+    /// Generate `expected_tier_tag()` — maps token names (including aliases) to
+    /// their FNV-1a tier tag constants.
+    ///
+    /// Used by `#[arcane]` to emit compile-time `const` assertions that verify
+    /// a concrete token type is genuinely the expected archmage type.
+    fn gen_expected_tier_tag(&self, out: &mut String, major_version: u32) {
+        use indoc::formatdoc;
+        out.push_str(&formatdoc! {"
+            /// Returns the expected tier tag for a concrete token type name.
+            ///
+            /// Used by `#[arcane]` to emit compile-time assertions.
+            /// Generated from token-registry.toml.
+            pub(crate) fn expected_tier_tag(token_name: &str) -> Option<u32> {{
+                match token_name {{
+        "});
+
+        // ScalarToken first
+        let scalar_tag = tier_tag("ScalarToken", major_version);
+        out.push_str(&format!(
+            "        \"ScalarToken\" => Some(0x{scalar_tag:08X}),\n"
+        ));
+
+        for token in &self.token {
+            let tag = tier_tag(&token.name, major_version);
+            let pattern = Self::match_pattern(token);
+            out.push_str(&format!("        {pattern} => Some(0x{tag:08X}),\n"));
+        }
+
+        out.push_str("        _ => None,\n");
+        out.push_str("    }\n}\n");
+    }
+
     fn gen_all_concrete_tokens(&self, out: &mut String) {
         out.push_str("/// All concrete token names that exist in the runtime crate.\n");
         out.push_str("#[cfg(test)]\n");
@@ -932,7 +984,7 @@ mod tests {
     #[test]
     fn macro_registry_contains_all_tokens() {
         let registry = load_test_registry();
-        let output = registry.generate_macro_registry();
+        let output = registry.generate_macro_registry(0);
 
         // Every token should appear in the generated registry
         for token in &registry.token {
@@ -956,7 +1008,7 @@ mod tests {
     #[test]
     fn macro_registry_contains_features() {
         let registry = load_test_registry();
-        let output = registry.generate_macro_registry();
+        let output = registry.generate_macro_registry(0);
 
         // Key features should appear in the output
         for feature in &["avx2", "fma", "neon", "simd128"] {

--- a/xtask/src/token_gen.rs
+++ b/xtask/src/token_gen.rs
@@ -6,7 +6,7 @@
 //! - Trait definitions
 //! - Module file with cfg-gated imports
 
-use crate::registry::{Registry, TokenDef, TraitDef};
+use crate::registry::{Registry, TokenDef, TraitDef, tier_tag};
 use indoc::formatdoc;
 
 /// Convert token name to a screaming snake case variable name with given suffix.
@@ -67,7 +67,7 @@ fn disabled_var_name(token_name: &str) -> String {
 /// All generated token files as (relative_path, content) pairs.
 ///
 /// Relative to `src/tokens/generated/`.
-pub fn generate_token_files(reg: &Registry) -> Vec<(String, String)> {
+pub fn generate_token_files(reg: &Registry, major_version: u32) -> Vec<(String, String)> {
     let mut files = Vec::new();
 
     // Collect deprecated trait names for #[allow(deprecated)] on impls
@@ -86,29 +86,35 @@ pub fn generate_token_files(reg: &Registry) -> Vec<(String, String)> {
     // Real implementations (all x86 tokens in one file — no base/avx512 split)
     files.push((
         "x86.rs".into(),
-        gen_real_tokens(reg, &x86_tokens, "x86", &deprecated_traits),
+        gen_real_tokens(reg, &x86_tokens, "x86", &deprecated_traits, major_version),
     ));
     files.push((
         "arm.rs".into(),
-        gen_real_tokens(reg, &arm_tokens, "aarch64", &deprecated_traits),
+        gen_real_tokens(
+            reg,
+            &arm_tokens,
+            "aarch64",
+            &deprecated_traits,
+            major_version,
+        ),
     ));
     files.push((
         "wasm.rs".into(),
-        gen_real_tokens(reg, &wasm_tokens, "wasm", &deprecated_traits),
+        gen_real_tokens(reg, &wasm_tokens, "wasm", &deprecated_traits, major_version),
     ));
 
     // Stubs (all x86 tokens in one file)
     files.push((
         "x86_stubs.rs".into(),
-        gen_stub_tokens(reg, &x86_tokens, &deprecated_traits),
+        gen_stub_tokens(reg, &x86_tokens, &deprecated_traits, major_version),
     ));
     files.push((
         "arm_stubs.rs".into(),
-        gen_stub_tokens(reg, &arm_tokens, &deprecated_traits),
+        gen_stub_tokens(reg, &arm_tokens, &deprecated_traits, major_version),
     ));
     files.push((
         "wasm_stubs.rs".into(),
-        gen_stub_tokens(reg, &wasm_tokens, &deprecated_traits),
+        gen_stub_tokens(reg, &wasm_tokens, &deprecated_traits, major_version),
     ));
 
     // Traits
@@ -129,6 +135,7 @@ fn gen_real_tokens(
     tokens: &[&TokenDef],
     arch: &str,
     deprecated_traits: &[&str],
+    major_version: u32,
 ) -> String {
     let mut out = String::with_capacity(4096);
 
@@ -224,6 +231,9 @@ fn gen_real_tokens(
     for token in tokens {
         gen_aliases(&mut out, token);
     }
+
+    // Tier tags — compile-time assertion constants
+    gen_tier_tags(&mut out, tokens, major_version);
 
     // Trait impls
     gen_trait_impls(&mut out, tokens, deprecated_traits);
@@ -819,7 +829,12 @@ fn collect_descendants<'a>(reg: &'a Registry, token: &'a TokenDef) -> Vec<&'a To
 // Stub token implementations (cross-platform)
 // ============================================================================
 
-fn gen_stub_tokens(reg: &Registry, tokens: &[&TokenDef], deprecated_traits: &[&str]) -> String {
+fn gen_stub_tokens(
+    reg: &Registry,
+    tokens: &[&TokenDef],
+    deprecated_traits: &[&str],
+    major_version: u32,
+) -> String {
     let _ = reg; // available if needed later
     let mut out = String::with_capacity(2048);
 
@@ -859,6 +874,9 @@ fn gen_stub_tokens(reg: &Registry, tokens: &[&TokenDef], deprecated_traits: &[&s
     for token in tokens {
         gen_aliases(&mut out, token);
     }
+
+    // Tier tags — compile-time assertion constants (same tags as real tokens)
+    gen_tier_tags(&mut out, tokens, major_version);
 
     // Trait impls (same as real — traits apply to stubs too for generic code)
     gen_trait_impls(&mut out, tokens, deprecated_traits);
@@ -989,6 +1007,30 @@ fn gen_trait_impls(out: &mut String, tokens: &[&TokenDef], deprecated_trait_name
             }
             out.push_str(&format!("impl {trait_name} for {token_name} {{}}\n"));
         }
+    }
+}
+
+// ============================================================================
+// Tier tags — compile-time assertion constants
+// ============================================================================
+
+/// Generate `__ARCHMAGE_TIER_TAG` inherent const impl blocks for each token struct.
+///
+/// These are used by `#[arcane]` to emit `const _: () = assert!(...)` checks
+/// that verify the token type is genuinely the expected archmage type, without
+/// requiring `::archmage::` in the expanded code.
+fn gen_tier_tags(out: &mut String, tokens: &[&TokenDef], major_version: u32) {
+    out.push('\n');
+    for token in tokens {
+        let name = &token.name;
+        let tag = tier_tag(name, major_version);
+        out.push_str(&formatdoc! {"
+            impl {name} {{
+                #[doc(hidden)]
+                pub const __ARCHMAGE_TIER_TAG: u32 = 0x{tag:08X};
+            }}
+
+        "});
     }
 }
 
@@ -1253,7 +1295,7 @@ mod tests {
     #[test]
     fn generates_expected_file_set() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
 
         // Must produce exactly these files
@@ -1283,7 +1325,7 @@ mod tests {
     #[test]
     fn x86_real_tokens_contain_all_x86_tokens() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let x86_code = &files.iter().find(|(n, _)| n == "x86.rs").unwrap().1;
 
         let x86_tokens: Vec<&str> = reg
@@ -1308,7 +1350,7 @@ mod tests {
     #[test]
     fn arm_real_tokens_contain_all_arm_tokens() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let arm_code = &files.iter().find(|(n, _)| n == "arm.rs").unwrap().1;
 
         let arm_tokens: Vec<&str> = reg
@@ -1333,7 +1375,7 @@ mod tests {
     #[test]
     fn stubs_return_none_for_summon() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
 
         for (name, code) in &files {
             if name.ends_with("_stubs.rs") {
@@ -1349,7 +1391,7 @@ mod tests {
     #[test]
     fn traits_file_contains_all_traits() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let traits_code = &files.iter().find(|(n, _)| n == "traits.rs").unwrap().1;
 
         for trait_def in &reg.traits {
@@ -1364,7 +1406,7 @@ mod tests {
     #[test]
     fn real_tokens_have_summon_and_compiled_with() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
 
         for (name, code) in &files {
             if name == "x86.rs" || name == "arm.rs" || name == "wasm.rs" {
@@ -1398,7 +1440,7 @@ mod tests {
     #[test]
     fn parent_extraction_methods_generated() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let x86_code = &files.iter().find(|(n, _)| n == "x86.rs").unwrap().1;
 
         // X64V3Token has parent X64V2Token — should generate extraction method
@@ -1437,7 +1479,7 @@ mod tests {
     #[test]
     fn mod_rs_routes_all_architectures() {
         let reg = load_test_registry();
-        let files = generate_token_files(&reg);
+        let files = generate_token_files(&reg, 0);
         let mod_code = &files.iter().find(|(n, _)| n == "mod.rs").unwrap().1;
 
         // Must have cfg routing for all architectures


### PR DESCRIPTION
## Summary

- Replace `::archmage::` path-based token assertion with compile-time const tier tag check
- Each token struct gets `pub const __ARCHMAGE_TIER_TAG: u32` (FNV-1a hash of name + major version)
- `#[arcane]` emits `const _: () = [()][!(<Type>::__ARCHMAGE_TIER_TAG == EXPECTED) as usize];` -- zero runtime cost, resolves through re-exports
- Enables re-exporters (like zenjxl-decoder-simd) to use `#[arcane]` without requiring consumers to depend on `archmage` directly

## Motivation

When `#[arcane]` is invoked through a re-exported proc-macro (e.g., `simd_function!` in zenjxl-decoder-simd applies `#[$crate::__arcane]`), the consumer crate (zenjxl-decoder) doesn't have `archmage` in its extern prelude. The old assertion emitted `::archmage::X64V3Token` which fails to resolve -- 117 compile errors.

The new assertion uses the token type's own `__ARCHMAGE_TIER_TAG` const, accessed via the type-as-written in the signature. This resolves through any re-export chain without needing `archmage` as a direct dependency.

## Security properties

- **Shadowing** still caught: local struct has no `__ARCHMAGE_TIER_TAG` -- compile error
- **Aliasing** still caught: wrong token has wrong tag value -- const assertion fails
- **Trait/generic bounds**: sealed `SimdToken` trait suffices, no assertion needed
- Tags rotate on major version bump (FNV-1a seeded with version)
- Zero runtime cost: assertion is `const _: ()`, vanishes from binary

## Test plan

- [x] All existing tests pass (compile-fail, soundness exploits, macro expansion snapshots)
- [x] Shadowing caught with updated error message
- [x] Aliasing caught with updated error message
- [x] `cargo xtask generate` regenerates consistently