### PR TITLE
fix: propagate doc comments and attrs in #[magetypes] variants

### DIFF
--- a/archmage-macros/src/magetypes.rs
+++ b/archmage-macros/src/magetypes.rs
@@ -14,7 +14,15 @@ pub(crate) fn magetypes_impl(mut input_fn: LightFn, tiers: &[ResolvedTier]) -> T
         .retain(|attr| !attr.path().is_ident("arcane") && !attr.path().is_ident("rite"));
 
     let fn_name = &input_fn.sig.ident;
-    let fn_attrs = &input_fn.attrs;
+
+    // Attrs to propagate to each variant: doc comments, #[allow], #[inline], etc.
+    // Exclude #[magetypes] (consumed) and #[arcane]/#[rite] (already stripped above).
+    let propagated_attrs: Vec<_> = input_fn
+        .attrs
+        .iter()
+        .filter(|a| !a.path().is_ident("magetypes"))
+        .cloned()
+        .collect();
 
     let mut variants = Vec::new();
 
@@ -22,8 +30,8 @@ pub(crate) fn magetypes_impl(mut input_fn: LightFn, tiers: &[ResolvedTier]) -> T
         // Clone and rename at the AST level (no string surgery)
         let mut variant_fn = input_fn.clone();
         variant_fn.sig.ident = quote::format_ident!("{}_{}", fn_name, tier.suffix);
-        // Strip attrs — they go on the outer wrapper, not each variant
-        variant_fn.attrs = Vec::new();
+        // Propagate doc comments, #[allow], etc. to each variant
+        variant_fn.attrs = propagated_attrs.clone();
 
         // Replace `Token` ident with the concrete token path at the token level.
         // This is safe: each identifier is a discrete token tree, so `ScalarToken`,
@@ -74,14 +82,7 @@ pub(crate) fn magetypes_impl(mut input_fn: LightFn, tiers: &[ResolvedTier]) -> T
         });
     }
 
-    // Remove attributes from the list that should not be duplicated
-    let filtered_attrs: Vec<_> = fn_attrs
-        .iter()
-        .filter(|a| !a.path().is_ident("magetypes"))
-        .collect();
-
     let output = quote! {
-        #(#filtered_attrs)*
         #(#variants)*
     };
 

--- a/magetypes/tests/magetypes_macro.rs
+++ b/magetypes/tests/magetypes_macro.rs
@@ -367,3 +367,53 @@ mod generic_magetypes_dispatch {
         assert!((result - 36.0).abs() < 0.01);
     }
 }
+
+// =============================================================================
+// Attribute propagation (#32)
+// =============================================================================
+
+/// Module uses `#[deny(missing_docs)]` to verify doc comments propagate
+/// to all generated variants. Before the fix, `#[magetypes]` stripped all
+/// attributes from variants, causing missing_docs warnings on `_v3`, `_neon`,
+/// `_wasm128`, and `_scalar` variants even when the template had a doc comment.
+#[deny(missing_docs)]
+mod attr_propagation {
+    use archmage::{ScalarToken, SimdToken, magetypes};
+
+    /// Documented function — doc must propagate to all variants.
+    #[magetypes]
+    pub fn documented(token: Token, x: f32) -> f32 {
+        let _ = token;
+        x + 1.0
+    }
+
+    /// Documented function with `#[allow(unused_variables)]`.
+    #[allow(unused_variables)]
+    #[magetypes]
+    pub fn with_allow(token: Token, x: f32, unused_arg: i32) -> f32 {
+        let _ = token;
+        x
+    }
+
+    /// Documented function with explicit tiers.
+    #[magetypes(v3, neon, scalar)]
+    pub fn documented_explicit(token: Token, x: f32) -> f32 {
+        let _ = token;
+        x * 2.0
+    }
+
+    #[test]
+    fn documented_scalar_works() {
+        assert_eq!(documented_scalar(ScalarToken, 1.0), 2.0);
+    }
+
+    #[test]
+    fn with_allow_scalar_works() {
+        assert_eq!(with_allow_scalar(ScalarToken, 5.0, 999), 5.0);
+    }
+
+    #[test]
+    fn documented_explicit_scalar_works() {
+        assert_eq!(documented_explicit_scalar(ScalarToken, 3.0), 6.0);
+    }
+}


### PR DESCRIPTION
## Summary

- `#[magetypes]` was stripping all attributes from generated variants (`variant_fn.attrs = Vec::new()`), then emitting the template's attrs once as a dangling prefix attached to nothing
- Now doc comments, `#[allow]`, `#[inline]`, and other user attributes are cloned onto each generated variant
- `#[magetypes]` itself and `#[arcane]`/`#[rite]` are still stripped (consumed by the macro)
- `#[rite]` and `#[autoversion]` are not affected — `#[rite]` already preserves user attrs via `filter_inline_attrs()`, and `#[autoversion]` moves attrs to the dispatcher (variants are private)

## Test plan

- [x] New `attr_propagation` module in `magetypes/tests/magetypes_macro.rs` with `#[deny(missing_docs)]` — verifies doc comments propagate to all generated variants
- [x] Tests for `#[allow(unused_variables)]` propagation
- [x] Tests with explicit tier lists (`#[magetypes(v3, neon, scalar)]`)
- [x] All existing tests pass (`cargo test --features "std avx512"`)
- [x] Clippy clean

Fixes #32