### PR TITLE
feat(magetypes): f32-chain cross-width with V4 native (closes #36)

### DIFF
--- a/magetypes/src/simd/generic/cross_width.rs
+++ b/magetypes/src/simd/generic/cross_width.rs
@@ -1,0 +1,550 @@
+//! Cross-width raising and lowering for the f32 generic SIMD chain.
+//!
+//! Provides token-gated `from_halves` (combine two narrower halves into a
+//! wider vector) and `low` / `high` / `split` (extract narrower halves)
+//! for the two adjacent width pairs of the f32 family:
+//!
+//! - `f32x4` ↔ `f32x8` (W128 ↔ W256), via [`F32x8FromHalves`]
+//! - `f32x8` ↔ `f32x16` (W256 ↔ W512), via [`F32x16FromHalves`]
+//!
+//! ## Why the token is load-bearing
+//!
+//! On x86, raising one tier (e.g. two `f32x4` into one `f32x8`) emits an
+//! AVX instruction (`vinsertf128`) whose execution requires the AVX
+//! target feature. The narrower vectors (`f32x4`) only require SSE; the
+//! AVX bit is supplied by the *wider* tier's token. Passing that token
+//! to `from_halves` is the proof that emitting AVX is sound. The token
+//! shape is uniform across tiers — even when no wider feature is needed
+//! (NEON / Wasm128 / Scalar reprs are already arrays of two narrower
+//! reprs, so combining is array-construction) — so callers don't need
+//! per-platform code.
+//!
+//! ## Deductive safety proof, per backend
+//!
+//! Each `from_halves` impl is sound when:
+//!
+//! 1. **Token guarantees runtime feature presence.** Constructing `T`
+//!    requires `T::summon()` (which performs runtime CPU feature
+//!    detection) or one of the upgrade extractors from a stronger token
+//!    that is itself proven by the same chain. The forge bypass
+//!    (`forge_token_dangerously`) is `unsafe` and explicitly off the
+//!    soundness chain.
+//!
+//! 2. **The repr-construction operation is sound under those features.**
+//!    For native intrinsic paths, the chosen instruction is documented
+//!    by the platform vendor as requiring exactly the features `T` proves
+//!    (X64V3Token ⇒ AVX, X64V4Token ⇒ AVX-512F+VL, NeonToken ⇒ AdvSIMD,
+//!    Wasm128Token ⇒ simd128, ScalarToken ⇒ no platform features).
+//!    For polyfilled paths (e.g. `[__m256; 2]` for `f32x16<X64V3Token>`),
+//!    the operation is array construction, which is sound on any platform.
+//!
+//! 3. **Repr produced is layout-compatible with the target type.** Both
+//!    `f32x{4,8,16}<T>` are `#[repr(C)]` over `(T::Repr, T)` where `T`
+//!    is a 1-ZST, so wrapping a freshly-constructed `Repr` via
+//!    `from_repr_unchecked(token, repr)` is sound — the token is
+//!    already proven by the caller's wider input type.
+//!
+//! Per-impl notes on the polyfill ↔ native distinction live next to
+//! each impl below.
+//!
+//! ## Native-when-possible, polyfill-when-not
+//!
+//! | Pair | Token | Wider Repr | from_halves emits |
+//! |---|---|---|---|
+//! | f32x4→f32x8 | ScalarToken | `[f32; 8]` | array concat (8 stores) |
+//! | f32x4→f32x8 | NeonToken | `[float32x4_t; 2]` | `[lo, hi]` (zero-cost) |
+//! | f32x4→f32x8 | Wasm128Token | `[v128; 2]` | `[lo, hi]` (zero-cost) |
+//! | f32x4→f32x8 | X64V3Token | `__m256` (AVX) | `vinsertf128` |
+//! | f32x4→f32x8 | X64V4Token | `__m256` (delegated) | `vinsertf128` |
+//! | f32x8→f32x16 | ScalarToken | `[f32; 16]` | array concat (16 stores) |
+//! | f32x8→f32x16 | NeonToken | `[float32x4_t; 4]` | `[lo[0], lo[1], hi[0], hi[1]]` |
+//! | f32x8→f32x16 | Wasm128Token | `[v128; 4]` | `[lo[0], lo[1], hi[0], hi[1]]` |
+//! | f32x8→f32x16 | X64V3Token | `[__m256; 2]` | `[lo, hi]` (polyfilled) |
+//! | f32x8→f32x16 | X64V4Token | `__m512` (AVX-512) | `vinsertf32x8` (native) |
+//!
+//! V4xToken / Avx512Fp16Token inherit X64V4Token's behavior at every
+//! width via the same backend delegation in `impls/x86_v4_f32_delegated.rs`.
+
+use archmage::SimdToken;
+
+#[cfg(feature = "w512")]
+use crate::simd::backends::F32x16Backend;
+use crate::simd::backends::sealed::Sealed;
+use crate::simd::backends::{F32x4Backend, F32x8Backend};
+#[cfg(feature = "w512")]
+use crate::simd::generic::f32x16;
+use crate::simd::generic::{f32x4, f32x8};
+
+// ============================================================================
+// W128 ↔ W256 — `f32x4` ↔ `f32x8`
+// ============================================================================
+
+/// Raise/lower between `f32x4<T>` and `f32x8<T>` for the same token `T`.
+///
+/// Implemented for every token that supplies both [`F32x4Backend`] and
+/// [`F32x8Backend`].
+pub trait F32x8FromHalves:
+    F32x8Backend + F32x4Backend + SimdToken + Sealed + Copy + 'static
+{
+    /// Combine two 128-bit halves into a 256-bit representation.
+    ///
+    /// The generic exposure on [`f32x8`] takes a token; this trait
+    /// method takes `self` (the token) so soundness flows through every
+    /// call — each impl can only be entered via a proven token.
+    fn from_halves(
+        self,
+        lo: <Self as F32x4Backend>::Repr,
+        hi: <Self as F32x4Backend>::Repr,
+    ) -> <Self as F32x8Backend>::Repr;
+
+    /// Extract the low 128-bit half of a 256-bit representation.
+    fn low(self, wide: <Self as F32x8Backend>::Repr) -> <Self as F32x4Backend>::Repr;
+
+    /// Extract the high 128-bit half of a 256-bit representation.
+    fn high(self, wide: <Self as F32x8Backend>::Repr) -> <Self as F32x4Backend>::Repr;
+}
+
+// X64V3Token (AVX) — load-bearing token, native intrinsics
+//
+// Soundness: X64V3Token's feature set includes AVX. `_mm256_insertf128_ps`
+// requires AVX (Intel SDM Vol. 2A, INSERTF128 — encoded as VEX.256), which
+// the token guarantees. `_mm256_castps128_ps256` is a no-op cast.
+// `_mm256_extractf128_ps` requires AVX (EXTRACTF128). All operate on stack
+// register state with no aliasing concerns.
+#[cfg(target_arch = "x86_64")]
+impl F32x8FromHalves for archmage::X64V3Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m128,
+        hi: core::arch::x86_64::__m128,
+    ) -> core::arch::x86_64::__m256 {
+        let _ = self;
+        // SAFETY: X64V3Token proves AVX is available; both args are valid
+        // initialized __m128 values; intrinsic is pure.
+        unsafe {
+            core::arch::x86_64::_mm256_insertf128_ps(
+                core::arch::x86_64::_mm256_castps128_ps256(lo),
+                hi,
+                1,
+            )
+        }
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        let _ = self;
+        // SAFETY: X64V3Token proves AVX. _mm256_castps256_ps128 is a free
+        // truncation (no instruction in well-optimized output).
+        unsafe { core::arch::x86_64::_mm256_castps256_ps128(wide) }
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        let _ = self;
+        // SAFETY: X64V3Token proves AVX. _mm256_extractf128_ps with imm=1
+        // returns the high lane; intrinsic is pure.
+        unsafe { core::arch::x86_64::_mm256_extractf128_ps(wide, 1) }
+    }
+}
+
+// X64V4Token / X64V4xToken / Avx512Fp16Token — same Repr as V3 (delegation
+// installed in impls/x86_v4_f32_delegated.rs). Soundness inherited from V3
+// by the V3 ⊊ V4 subset relation (proved in that file's module doc).
+// Each impl downcasts via the guaranteed `.v3()` extractor and forwards.
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+impl F32x8FromHalves for archmage::X64V4Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m128,
+        hi: core::arch::x86_64::__m128,
+    ) -> core::arch::x86_64::__m256 {
+        <archmage::X64V3Token as F32x8FromHalves>::from_halves(self.v3(), lo, hi)
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::low(self.v3(), wide)
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::high(self.v3(), wide)
+    }
+}
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+impl F32x8FromHalves for archmage::X64V4xToken {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m128,
+        hi: core::arch::x86_64::__m128,
+    ) -> core::arch::x86_64::__m256 {
+        <archmage::X64V3Token as F32x8FromHalves>::from_halves(self.v3(), lo, hi)
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::low(self.v3(), wide)
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::high(self.v3(), wide)
+    }
+}
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+impl F32x8FromHalves for archmage::Avx512Fp16Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m128,
+        hi: core::arch::x86_64::__m128,
+    ) -> core::arch::x86_64::__m256 {
+        <archmage::X64V3Token as F32x8FromHalves>::from_halves(self.v3(), lo, hi)
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::low(self.v3(), wide)
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m256) -> core::arch::x86_64::__m128 {
+        <archmage::X64V3Token as F32x8FromHalves>::high(self.v3(), wide)
+    }
+}
+
+// NeonToken — polyfilled wider Repr. Soundness: array construction; no
+// platform feature beyond what NeonToken already proves (AdvSIMD).
+#[cfg(target_arch = "aarch64")]
+impl F32x8FromHalves for archmage::NeonToken {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::aarch64::float32x4_t,
+        hi: core::arch::aarch64::float32x4_t,
+    ) -> [core::arch::aarch64::float32x4_t; 2] {
+        let _ = self;
+        [lo, hi]
+    }
+    #[inline(always)]
+    fn low(self, wide: [core::arch::aarch64::float32x4_t; 2]) -> core::arch::aarch64::float32x4_t {
+        let _ = self;
+        wide[0]
+    }
+    #[inline(always)]
+    fn high(self, wide: [core::arch::aarch64::float32x4_t; 2]) -> core::arch::aarch64::float32x4_t {
+        let _ = self;
+        wide[1]
+    }
+}
+
+// Wasm128Token — same shape as NEON: polyfill via `[v128; 2]`.
+#[cfg(target_arch = "wasm32")]
+impl F32x8FromHalves for archmage::Wasm128Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::wasm32::v128,
+        hi: core::arch::wasm32::v128,
+    ) -> [core::arch::wasm32::v128; 2] {
+        let _ = self;
+        [lo, hi]
+    }
+    #[inline(always)]
+    fn low(self, wide: [core::arch::wasm32::v128; 2]) -> core::arch::wasm32::v128 {
+        let _ = self;
+        wide[0]
+    }
+    #[inline(always)]
+    fn high(self, wide: [core::arch::wasm32::v128; 2]) -> core::arch::wasm32::v128 {
+        let _ = self;
+        wide[1]
+    }
+}
+
+// ScalarToken — pure array math. Sound on every platform.
+impl F32x8FromHalves for archmage::ScalarToken {
+    #[inline(always)]
+    fn from_halves(self, lo: [f32; 4], hi: [f32; 4]) -> [f32; 8] {
+        let _ = self;
+        [lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3]]
+    }
+    #[inline(always)]
+    fn low(self, wide: [f32; 8]) -> [f32; 4] {
+        let _ = self;
+        [wide[0], wide[1], wide[2], wide[3]]
+    }
+    #[inline(always)]
+    fn high(self, wide: [f32; 8]) -> [f32; 4] {
+        let _ = self;
+        [wide[4], wide[5], wide[6], wide[7]]
+    }
+}
+
+impl<T: F32x8FromHalves> f32x8<T> {
+    /// Combine two `f32x4<T>` halves into one `f32x8<T>`.
+    ///
+    /// The token is load-bearing on x86 (proves AVX); a no-op on other
+    /// tiers but kept in the signature for uniform use.
+    #[inline(always)]
+    pub fn from_halves(token: T, lo: f32x4<T>, hi: f32x4<T>) -> Self {
+        Self::from_repr_unchecked(
+            token,
+            <T as F32x8FromHalves>::from_halves(token, lo.into_repr(), hi.into_repr()),
+        )
+    }
+    /// Extract the low 128-bit half.
+    #[inline(always)]
+    pub fn low(self) -> f32x4<T> {
+        f32x4::from_repr_unchecked(
+            self.1,
+            <T as F32x8FromHalves>::low(self.1, self.into_repr()),
+        )
+    }
+    /// Extract the high 128-bit half.
+    #[inline(always)]
+    pub fn high(self) -> f32x4<T> {
+        f32x4::from_repr_unchecked(
+            self.1,
+            <T as F32x8FromHalves>::high(self.1, self.into_repr()),
+        )
+    }
+    /// Split into `(low, high)` halves.
+    #[inline(always)]
+    pub fn split(self) -> (f32x4<T>, f32x4<T>) {
+        (self.low(), self.high())
+    }
+}
+
+// ============================================================================
+// W256 ↔ W512 — `f32x8` ↔ `f32x16`
+// ============================================================================
+
+/// Raise/lower between `f32x8<T>` and `f32x16<T>` for the same token `T`.
+///
+/// Same shape as [`F32x8FromHalves`], one tier wider. Implemented for
+/// every token that supplies both [`F32x8Backend`] and [`F32x16Backend`].
+///
+/// Gated behind magetypes' `w512` feature (default-on) since
+/// `F32x16Backend` itself is `w512`-gated.
+#[cfg(feature = "w512")]
+pub trait F32x16FromHalves:
+    F32x16Backend + F32x8Backend + SimdToken + Sealed + Copy + 'static
+{
+    /// Combine two 256-bit halves into a 512-bit representation.
+    fn from_halves(
+        self,
+        lo: <Self as F32x8Backend>::Repr,
+        hi: <Self as F32x8Backend>::Repr,
+    ) -> <Self as F32x16Backend>::Repr;
+
+    /// Extract the low 256-bit half of a 512-bit representation.
+    fn low(self, wide: <Self as F32x16Backend>::Repr) -> <Self as F32x8Backend>::Repr;
+
+    /// Extract the high 256-bit half of a 512-bit representation.
+    fn high(self, wide: <Self as F32x16Backend>::Repr) -> <Self as F32x8Backend>::Repr;
+}
+
+// X64V3Token — f32x16 polyfills to `[__m256; 2]`. Sound: array construction;
+// no AVX-512 needed (the polyfill repr stays in V3 territory).
+#[cfg(all(target_arch = "x86_64", feature = "w512"))]
+impl F32x16FromHalves for archmage::X64V3Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m256,
+        hi: core::arch::x86_64::__m256,
+    ) -> [core::arch::x86_64::__m256; 2] {
+        let _ = self;
+        [lo, hi]
+    }
+    #[inline(always)]
+    fn low(self, wide: [core::arch::x86_64::__m256; 2]) -> core::arch::x86_64::__m256 {
+        let _ = self;
+        wide[0]
+    }
+    #[inline(always)]
+    fn high(self, wide: [core::arch::x86_64::__m256; 2]) -> core::arch::x86_64::__m256 {
+        let _ = self;
+        wide[1]
+    }
+}
+
+// X64V4Token — native AVX-512. f32x16<V4>::Repr is `__m512`; f32x8<V4>::Repr
+// is V3-delegated `__m256`.
+//
+// Soundness: V4 token proves AVX-512F + AVX-512DQ + AVX-512VL.
+// `_mm512_insertf32x8` (Intel SDM, VINSERTF32X8 — EVEX.512) requires
+// AVX-512DQ for the variant taking a __m256, which V4 includes.
+// `_mm512_castps256_ps512` is a no-op cast (the upper bits are immediately
+// overwritten by the insert). For low/high: `_mm512_castps512_ps256`
+// truncates; `_mm512_extractf32x8_ps` (AVX-512DQ) returns the high 256-bit
+// lane.
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+impl F32x16FromHalves for archmage::X64V4Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m256,
+        hi: core::arch::x86_64::__m256,
+    ) -> core::arch::x86_64::__m512 {
+        let _ = self;
+        // SAFETY: V4 proves AVX-512F + AVX-512DQ + AVX-512VL.
+        unsafe {
+            core::arch::x86_64::_mm512_insertf32x8(
+                core::arch::x86_64::_mm512_castps256_ps512(lo),
+                hi,
+                1,
+            )
+        }
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m512) -> core::arch::x86_64::__m256 {
+        let _ = self;
+        // SAFETY: V4 proves AVX-512. _mm512_castps512_ps256 is a free truncation.
+        unsafe { core::arch::x86_64::_mm512_castps512_ps256(wide) }
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m512) -> core::arch::x86_64::__m256 {
+        let _ = self;
+        // SAFETY: V4 proves AVX-512DQ. _mm512_extractf32x8_ps requires DQ.
+        unsafe { core::arch::x86_64::_mm512_extractf32x8_ps(wide, 1) }
+    }
+}
+
+// X64V4xToken — same as V4 (DQ available, additional extensions don't
+// change f32x16's representation). Forwarded via `.v4()` extractor.
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+impl F32x16FromHalves for archmage::X64V4xToken {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: core::arch::x86_64::__m256,
+        hi: core::arch::x86_64::__m256,
+    ) -> core::arch::x86_64::__m512 {
+        <archmage::X64V4Token as F32x16FromHalves>::from_halves(self.v4(), lo, hi)
+    }
+    #[inline(always)]
+    fn low(self, wide: core::arch::x86_64::__m512) -> core::arch::x86_64::__m256 {
+        <archmage::X64V4Token as F32x16FromHalves>::low(self.v4(), wide)
+    }
+    #[inline(always)]
+    fn high(self, wide: core::arch::x86_64::__m512) -> core::arch::x86_64::__m256 {
+        <archmage::X64V4Token as F32x16FromHalves>::high(self.v4(), wide)
+    }
+}
+// Avx512Fp16Token does NOT implement F32x16Backend on origin/main, so it
+// cannot implement F32x16FromHalves. Users with an Avx512Fp16Token who need
+// f32x16 must extract to X64V4Token first via the standard token-extractor
+// chain. (Avx512Fp16Token does have F32x4 / F32x8 via the delegation in
+// `impls/x86_v4_f32_delegated.rs`, so the W128↔W256 pair above works for it.)
+
+// NeonToken — cascade polyfill. f32x8<NEON> is `[float32x4_t; 2]`,
+// f32x16<NEON> is `[float32x4_t; 4]`. from_halves flattens.
+#[cfg(all(target_arch = "aarch64", feature = "w512"))]
+impl F32x16FromHalves for archmage::NeonToken {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: [core::arch::aarch64::float32x4_t; 2],
+        hi: [core::arch::aarch64::float32x4_t; 2],
+    ) -> [core::arch::aarch64::float32x4_t; 4] {
+        let _ = self;
+        [lo[0], lo[1], hi[0], hi[1]]
+    }
+    #[inline(always)]
+    fn low(
+        self,
+        wide: [core::arch::aarch64::float32x4_t; 4],
+    ) -> [core::arch::aarch64::float32x4_t; 2] {
+        let _ = self;
+        [wide[0], wide[1]]
+    }
+    #[inline(always)]
+    fn high(
+        self,
+        wide: [core::arch::aarch64::float32x4_t; 4],
+    ) -> [core::arch::aarch64::float32x4_t; 2] {
+        let _ = self;
+        [wide[2], wide[3]]
+    }
+}
+
+// Wasm128Token — cascade polyfill, same shape as NEON.
+#[cfg(all(target_arch = "wasm32", feature = "w512"))]
+impl F32x16FromHalves for archmage::Wasm128Token {
+    #[inline(always)]
+    fn from_halves(
+        self,
+        lo: [core::arch::wasm32::v128; 2],
+        hi: [core::arch::wasm32::v128; 2],
+    ) -> [core::arch::wasm32::v128; 4] {
+        let _ = self;
+        [lo[0], lo[1], hi[0], hi[1]]
+    }
+    #[inline(always)]
+    fn low(self, wide: [core::arch::wasm32::v128; 4]) -> [core::arch::wasm32::v128; 2] {
+        let _ = self;
+        [wide[0], wide[1]]
+    }
+    #[inline(always)]
+    fn high(self, wide: [core::arch::wasm32::v128; 4]) -> [core::arch::wasm32::v128; 2] {
+        let _ = self;
+        [wide[2], wide[3]]
+    }
+}
+
+// ScalarToken — pure array math.
+#[cfg(feature = "w512")]
+impl F32x16FromHalves for archmage::ScalarToken {
+    #[inline(always)]
+    fn from_halves(self, lo: [f32; 8], hi: [f32; 8]) -> [f32; 16] {
+        let _ = self;
+        let mut out = [0.0f32; 16];
+        out[..8].copy_from_slice(&lo);
+        out[8..].copy_from_slice(&hi);
+        out
+    }
+    #[inline(always)]
+    fn low(self, wide: [f32; 16]) -> [f32; 8] {
+        let _ = self;
+        let mut out = [0.0f32; 8];
+        out.copy_from_slice(&wide[..8]);
+        out
+    }
+    #[inline(always)]
+    fn high(self, wide: [f32; 16]) -> [f32; 8] {
+        let _ = self;
+        let mut out = [0.0f32; 8];
+        out.copy_from_slice(&wide[8..]);
+        out
+    }
+}
+
+#[cfg(feature = "w512")]
+impl<T: F32x16FromHalves> f32x16<T> {
+    /// Combine two `f32x8<T>` halves into one `f32x16<T>`.
+    #[inline(always)]
+    pub fn from_halves(token: T, lo: f32x8<T>, hi: f32x8<T>) -> Self {
+        Self::from_repr_unchecked(
+            token,
+            <T as F32x16FromHalves>::from_halves(token, lo.into_repr(), hi.into_repr()),
+        )
+    }
+    /// Extract the low 256-bit half.
+    #[inline(always)]
+    pub fn low(self) -> f32x8<T> {
+        f32x8::from_repr_unchecked(
+            self.1,
+            <T as F32x16FromHalves>::low(self.1, self.into_repr()),
+        )
+    }
+    /// Extract the high 256-bit half.
+    #[inline(always)]
+    pub fn high(self) -> f32x8<T> {
+        f32x8::from_repr_unchecked(
+            self.1,
+            <T as F32x16FromHalves>::high(self.1, self.into_repr()),
+        )
+    }
+    /// Split into `(low, high)` halves.
+    #[inline(always)]
+    pub fn split(self) -> (f32x8<T>, f32x8<T>) {
+        (self.low(), self.high())
+    }
+}

--- a/magetypes/src/simd/generic/mod.rs
+++ b/magetypes/src/simd/generic/mod.rs
@@ -8,5 +8,9 @@
 //! by `cargo xtask generate`. This file is handwritten and should not be
 //! purged during regeneration.
 
+mod cross_width;
 mod generated;
+pub use cross_width::F32x8FromHalves;
+#[cfg(feature = "w512")]
+pub use cross_width::F32x16FromHalves;
 pub use generated::*;

--- a/magetypes/src/simd/impls/mod.rs
+++ b/magetypes/src/simd/impls/mod.rs
@@ -11,6 +11,11 @@ mod x86_v3;
 #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 mod x86_v4;
 
+// V4-family delegation of W128 / W256 f32 backends to V3 (hand-written —
+// future generators may take it over). V4 ⊃ V3, so delegating is sound.
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+mod x86_v4_f32_delegated;
+
 #[cfg(target_arch = "aarch64")]
 mod arm_neon;
 

--- a/magetypes/src/simd/impls/x86_v4_f32_delegated.rs
+++ b/magetypes/src/simd/impls/x86_v4_f32_delegated.rs
@@ -1,0 +1,423 @@
+//! W128 / W256 f32 backend delegation for `X64V4Token` / `X64V4xToken` /
+//! `Avx512Fp16Token`.
+//!
+//! ## Why this file exists
+//!
+//! `X64V4Token` and friends advertise AVX-512 (W512) support but do not
+//! ship their own implementations of the narrower [`F32x4Backend`] /
+//! [`F32x8Backend`] traits. Without these, generic code parameterized on
+//! `T: F32x8Backend` cannot accept a V4 token, and the cross-width
+//! [`F32x16FromHalves`](crate::simd::generic::F32x16FromHalves) primitive
+//! cannot accept a V4 token either — even though V4's native AVX-512
+//! `_mm512_insertf32x8` is the intended optimal path.
+//!
+//! ## Deductive safety proof
+//!
+//! `X64V4Token`'s feature set is, per the registry:
+//!
+//!   `V4 = {sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, cmpxchg16b,`
+//!         `avx, avx2, fma, bmi1, bmi2, f16c, lzcnt, movbe,`
+//!         `pclmulqdq, aes, avx512f, avx512bw, avx512cd, avx512dq, avx512vl}`
+//!
+//! `X64V3Token`'s feature set is:
+//!
+//!   `V3 = {sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, cmpxchg16b,`
+//!         `avx, avx2, fma, bmi1, bmi2, f16c, lzcnt, movbe}`
+//!
+//! Therefore `V3 ⊊ V4` (strict subset). Any instruction encoding safe to
+//! execute on a CPU presenting V4's features is also safe under V3's
+//! features — the V4 platform is a strict superset of V3 capabilities.
+//!
+//! [`F32x4Backend`] / [`F32x8Backend`] for `X64V3Token` use intrinsics
+//! drawn from the V3 feature set (SSE / AVX / AVX2 / FMA, no AVX-512).
+//! Delegating V4's narrower-width methods to V3's implementations is
+//! therefore sound: every call site that was sound under a V3 token is
+//! sound under a V4 token by the subset relation, and the `Self::Repr`
+//! associated type stays identical (`__m128` / `__m256`) so caller code
+//! does not observe a representation change.
+//!
+//! Each delegating method calls the target V3 method with the downcast
+//! token supplied by the guaranteed `.v3()` extractor — the soundness
+//! chain stays explicit at every call.
+//!
+//! `X64V4xToken` and `Avx512Fp16Token` are V4 plus additional AVX-512
+//! sub-features (BITALG / VPOPCNTDQ for V4x; FP16 for Avx512Fp16Token);
+//! they are also strict supersets of V3 by the same argument.
+//!
+//! ## What this enables
+//!
+//! After this file:
+//! - `f32x4<X64V4Token>`, `f32x8<X64V4Token>` are constructible.
+//! - The cross-width `from_halves` / `low` / `high` family lights up
+//!   for V4 tokens at every width (W128↔W256 inherits V3's AVX behavior;
+//!   W256↔W512 uses V4's native `_mm512_insertf32x8`).
+//! - Generic `T: F32x8Backend` code accepts V4 tokens unchanged.
+
+#![cfg(all(target_arch = "x86_64", feature = "avx512"))]
+
+use crate::simd::backends::{F32x4Backend, F32x8Backend};
+
+/// Delegate every [`F32x4Backend`] method on `$token` to `X64V3Token`'s
+/// impl. `Self::Repr` is set to V3's repr (`__m128`); all method bodies
+/// forward through the trait's UFCS path, using the guaranteed `.v3()`
+/// extractor on the passed token.
+macro_rules! delegate_f32x4_to_v3 {
+    ($token:ty) => {
+        impl F32x4Backend for $token {
+            type Repr = <archmage::X64V3Token as F32x4Backend>::Repr;
+
+            // Construction
+            #[inline(always)]
+            fn splat(self, v: f32) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::splat(self.v3(), v)
+            }
+            #[inline(always)]
+            fn zero(self) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::zero(self.v3())
+            }
+            #[inline(always)]
+            fn load(self, d: &[f32; 4]) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::load(self.v3(), d)
+            }
+            #[inline(always)]
+            fn from_array(self, a: [f32; 4]) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::from_array(self.v3(), a)
+            }
+            #[inline(always)]
+            fn store(self, r: Self::Repr, o: &mut [f32; 4]) {
+                <archmage::X64V3Token as F32x4Backend>::store(self.v3(), r, o)
+            }
+            #[inline(always)]
+            fn to_array(self, r: Self::Repr) -> [f32; 4] {
+                <archmage::X64V3Token as F32x4Backend>::to_array(self.v3(), r)
+            }
+
+            // Arithmetic
+            #[inline(always)]
+            fn add(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::add(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn sub(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::sub(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn mul(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::mul(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn div(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::div(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn neg(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::neg(self.v3(), a)
+            }
+
+            // Math
+            #[inline(always)]
+            fn min(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::min(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn max(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::max(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn sqrt(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::sqrt(self.v3(), a)
+            }
+            #[inline(always)]
+            fn abs(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::abs(self.v3(), a)
+            }
+            #[inline(always)]
+            fn floor(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::floor(self.v3(), a)
+            }
+            #[inline(always)]
+            fn ceil(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::ceil(self.v3(), a)
+            }
+            #[inline(always)]
+            fn round(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::round(self.v3(), a)
+            }
+            #[inline(always)]
+            fn mul_add(self, a: Self::Repr, b: Self::Repr, c: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::mul_add(self.v3(), a, b, c)
+            }
+            #[inline(always)]
+            fn mul_sub(self, a: Self::Repr, b: Self::Repr, c: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::mul_sub(self.v3(), a, b, c)
+            }
+
+            // Comparisons
+            #[inline(always)]
+            fn simd_eq(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_eq(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_ne(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_ne(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_lt(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_lt(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_le(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_le(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_gt(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_gt(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_ge(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::simd_ge(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn blend(self, m: Self::Repr, t: Self::Repr, f: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::blend(self.v3(), m, t, f)
+            }
+
+            // Reductions
+            #[inline(always)]
+            fn reduce_add(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x4Backend>::reduce_add(self.v3(), a)
+            }
+            #[inline(always)]
+            fn reduce_min(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x4Backend>::reduce_min(self.v3(), a)
+            }
+            #[inline(always)]
+            fn reduce_max(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x4Backend>::reduce_max(self.v3(), a)
+            }
+
+            // Approximations (override defaults to preserve V3's hardware-rcp/rsqrt)
+            #[inline(always)]
+            fn rcp_approx(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::rcp_approx(self.v3(), a)
+            }
+            #[inline(always)]
+            fn rsqrt_approx(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::rsqrt_approx(self.v3(), a)
+            }
+            #[inline(always)]
+            fn recip(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::recip(self.v3(), a)
+            }
+            #[inline(always)]
+            fn rsqrt(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::rsqrt(self.v3(), a)
+            }
+
+            // Bitwise
+            #[inline(always)]
+            fn not(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::not(self.v3(), a)
+            }
+            #[inline(always)]
+            fn bitand(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::bitand(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn bitor(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::bitor(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn bitxor(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::bitxor(self.v3(), a, b)
+            }
+
+            // Default-having helpers (override to keep V3's hardware path)
+            #[inline(always)]
+            fn clamp(self, a: Self::Repr, lo: Self::Repr, hi: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x4Backend>::clamp(self.v3(), a, lo, hi)
+            }
+        }
+    };
+}
+
+/// Same delegation pattern for [`F32x8Backend`].
+macro_rules! delegate_f32x8_to_v3 {
+    ($token:ty) => {
+        impl F32x8Backend for $token {
+            type Repr = <archmage::X64V3Token as F32x8Backend>::Repr;
+
+            #[inline(always)]
+            fn splat(self, v: f32) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::splat(self.v3(), v)
+            }
+            #[inline(always)]
+            fn zero(self) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::zero(self.v3())
+            }
+            #[inline(always)]
+            fn load(self, d: &[f32; 8]) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::load(self.v3(), d)
+            }
+            #[inline(always)]
+            fn from_array(self, a: [f32; 8]) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::from_array(self.v3(), a)
+            }
+            #[inline(always)]
+            fn store(self, r: Self::Repr, o: &mut [f32; 8]) {
+                <archmage::X64V3Token as F32x8Backend>::store(self.v3(), r, o)
+            }
+            #[inline(always)]
+            fn to_array(self, r: Self::Repr) -> [f32; 8] {
+                <archmage::X64V3Token as F32x8Backend>::to_array(self.v3(), r)
+            }
+
+            #[inline(always)]
+            fn add(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::add(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn sub(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::sub(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn mul(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::mul(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn div(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::div(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn neg(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::neg(self.v3(), a)
+            }
+
+            #[inline(always)]
+            fn min(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::min(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn max(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::max(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn sqrt(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::sqrt(self.v3(), a)
+            }
+            #[inline(always)]
+            fn abs(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::abs(self.v3(), a)
+            }
+            #[inline(always)]
+            fn floor(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::floor(self.v3(), a)
+            }
+            #[inline(always)]
+            fn ceil(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::ceil(self.v3(), a)
+            }
+            #[inline(always)]
+            fn round(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::round(self.v3(), a)
+            }
+            #[inline(always)]
+            fn mul_add(self, a: Self::Repr, b: Self::Repr, c: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::mul_add(self.v3(), a, b, c)
+            }
+            #[inline(always)]
+            fn mul_sub(self, a: Self::Repr, b: Self::Repr, c: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::mul_sub(self.v3(), a, b, c)
+            }
+
+            #[inline(always)]
+            fn simd_eq(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_eq(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_ne(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_ne(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_lt(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_lt(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_le(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_le(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_gt(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_gt(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn simd_ge(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::simd_ge(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn blend(self, m: Self::Repr, t: Self::Repr, f: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::blend(self.v3(), m, t, f)
+            }
+
+            #[inline(always)]
+            fn reduce_add(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x8Backend>::reduce_add(self.v3(), a)
+            }
+            #[inline(always)]
+            fn reduce_min(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x8Backend>::reduce_min(self.v3(), a)
+            }
+            #[inline(always)]
+            fn reduce_max(self, a: Self::Repr) -> f32 {
+                <archmage::X64V3Token as F32x8Backend>::reduce_max(self.v3(), a)
+            }
+
+            #[inline(always)]
+            fn rcp_approx(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::rcp_approx(self.v3(), a)
+            }
+            #[inline(always)]
+            fn rsqrt_approx(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::rsqrt_approx(self.v3(), a)
+            }
+            #[inline(always)]
+            fn recip(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::recip(self.v3(), a)
+            }
+            #[inline(always)]
+            fn rsqrt(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::rsqrt(self.v3(), a)
+            }
+
+            #[inline(always)]
+            fn not(self, a: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::not(self.v3(), a)
+            }
+            #[inline(always)]
+            fn bitand(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::bitand(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn bitor(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::bitor(self.v3(), a, b)
+            }
+            #[inline(always)]
+            fn bitxor(self, a: Self::Repr, b: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::bitxor(self.v3(), a, b)
+            }
+
+            #[inline(always)]
+            fn clamp(self, a: Self::Repr, lo: Self::Repr, hi: Self::Repr) -> Self::Repr {
+                <archmage::X64V3Token as F32x8Backend>::clamp(self.v3(), a, lo, hi)
+            }
+        }
+    };
+}
+
+delegate_f32x4_to_v3!(archmage::X64V4Token);
+delegate_f32x4_to_v3!(archmage::X64V4xToken);
+delegate_f32x4_to_v3!(archmage::Avx512Fp16Token);
+
+delegate_f32x8_to_v3!(archmage::X64V4Token);
+delegate_f32x8_to_v3!(archmage::X64V4xToken);
+delegate_f32x8_to_v3!(archmage::Avx512Fp16Token);

--- a/magetypes/tests/cross_width_adversarial.rs
+++ b/magetypes/tests/cross_width_adversarial.rs
@@ -1,0 +1,444 @@
+//! Adversarial tests for [`F32x8FromHalves`] and [`F32x16FromHalves`].
+//!
+//! These tests try to break the contract: confirm lane order under every
+//! backend, prove polyfill paths agree with native intrinsics on the same
+//! inputs, exercise round-trip / idempotency invariants, and verify the
+//! Scalar reference matches every other backend.
+
+use archmage::{ScalarToken, SimdToken};
+use magetypes::simd::generic::{F32x8FromHalves, f32x4, f32x8};
+#[cfg(feature = "w512")]
+use magetypes::simd::generic::{F32x16FromHalves, f32x16};
+
+// Inputs chosen so each lane is unique and bit-distinguishable —
+// catches lane-shuffling regressions even at single-bit granularity.
+const F32X4_A: [f32; 4] = [1.0, 2.5, -3.25, 4.125];
+const F32X4_B: [f32; 4] = [5.0625, -6.0, 7.5, 8.0];
+const F32X4_C: [f32; 4] = [9.0, 10.0, 11.0, 12.0];
+const F32X4_D: [f32; 4] = [13.0, 14.0, 15.0, 16.0];
+
+const F32X8_LO: [f32; 8] = [1.0, 2.5, -3.25, 4.125, 5.0625, -6.0, 7.5, 8.0];
+const F32X8_HI: [f32; 8] = [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0];
+
+// ============================================================================
+// W128 → W256 (f32x4 → f32x8)
+// ============================================================================
+
+/// Lane order: from_halves(lo, hi) MUST produce
+///   [lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3]]
+/// for every backend. A regression where the halves swap or interleave
+/// would corrupt downstream math without crashing.
+fn lane_order_f32x8<T: F32x8FromHalves>(token: T) {
+    let lo = f32x4::<T>::from_array(token, F32X4_A);
+    let hi = f32x4::<T>::from_array(token, F32X4_B);
+    let wide = f32x8::<T>::from_halves(token, lo, hi);
+    let actual = wide.to_array();
+    let expected = [
+        F32X4_A[0], F32X4_A[1], F32X4_A[2], F32X4_A[3], F32X4_B[0], F32X4_B[1], F32X4_B[2],
+        F32X4_B[3],
+    ];
+    assert_eq!(actual, expected, "lane order f32x4→f32x8 broke");
+}
+
+/// Round-trip: split-after-from is identity.
+fn roundtrip_f32x8<T: F32x8FromHalves>(token: T) {
+    let lo = f32x4::<T>::from_array(token, F32X4_A);
+    let hi = f32x4::<T>::from_array(token, F32X4_B);
+    let wide = f32x8::<T>::from_halves(token, lo, hi);
+    let (back_lo, back_hi) = wide.split();
+    assert_eq!(back_lo.to_array(), F32X4_A);
+    assert_eq!(back_hi.to_array(), F32X4_B);
+}
+
+/// Reverse round-trip: from-after-split is identity.
+fn reverse_roundtrip_f32x8<T: F32x8FromHalves>(token: T) {
+    let original_lanes: [f32; 8] = [
+        F32X4_A[0], F32X4_A[1], F32X4_A[2], F32X4_A[3], F32X4_B[0], F32X4_B[1], F32X4_B[2],
+        F32X4_B[3],
+    ];
+    let original = f32x8::<T>::from_array(token, original_lanes);
+    let (lo, hi) = original.split();
+    let rebuilt = f32x8::<T>::from_halves(token, lo, hi);
+    assert_eq!(rebuilt.to_array(), original_lanes, "from(split(x)) ≠ x");
+}
+
+/// Cross-backend parity: every backend must agree with Scalar lane-for-lane.
+/// Catches the case where a polyfill / native-intrinsic disagree on lane order.
+fn parity_with_scalar_f32x8<T: F32x8FromHalves>(token: T) {
+    let scalar_token = ScalarToken::summon().unwrap();
+    let lo_t = f32x4::<T>::from_array(token, F32X4_A);
+    let hi_t = f32x4::<T>::from_array(token, F32X4_B);
+    let lo_s = f32x4::<ScalarToken>::from_array(scalar_token, F32X4_A);
+    let hi_s = f32x4::<ScalarToken>::from_array(scalar_token, F32X4_B);
+    let wide_t = f32x8::<T>::from_halves(token, lo_t, hi_t);
+    let wide_s = f32x8::<ScalarToken>::from_halves(scalar_token, lo_s, hi_s);
+    assert_eq!(
+        wide_t.to_array(),
+        wide_s.to_array(),
+        "backend-vs-scalar parity failed"
+    );
+    assert_eq!(wide_t.low().to_array(), wide_s.low().to_array());
+    assert_eq!(wide_t.high().to_array(), wide_s.high().to_array());
+}
+
+// ============================================================================
+// W256 → W512 (f32x8 → f32x16) — gated on `w512` magetypes feature
+// ============================================================================
+
+#[cfg(feature = "w512")]
+fn lane_order_f32x16<T: F32x16FromHalves>(token: T) {
+    let lo = f32x8::<T>::from_array(token, F32X8_LO);
+    let hi = f32x8::<T>::from_array(token, F32X8_HI);
+    let wide = f32x16::<T>::from_halves(token, lo, hi);
+    let actual = wide.to_array();
+    let expected = [
+        F32X8_LO[0],
+        F32X8_LO[1],
+        F32X8_LO[2],
+        F32X8_LO[3],
+        F32X8_LO[4],
+        F32X8_LO[5],
+        F32X8_LO[6],
+        F32X8_LO[7],
+        F32X8_HI[0],
+        F32X8_HI[1],
+        F32X8_HI[2],
+        F32X8_HI[3],
+        F32X8_HI[4],
+        F32X8_HI[5],
+        F32X8_HI[6],
+        F32X8_HI[7],
+    ];
+    assert_eq!(actual, expected, "lane order f32x8→f32x16 broke");
+}
+
+#[cfg(feature = "w512")]
+fn roundtrip_f32x16<T: F32x16FromHalves>(token: T) {
+    let lo = f32x8::<T>::from_array(token, F32X8_LO);
+    let hi = f32x8::<T>::from_array(token, F32X8_HI);
+    let wide = f32x16::<T>::from_halves(token, lo, hi);
+    let (back_lo, back_hi) = wide.split();
+    assert_eq!(back_lo.to_array(), F32X8_LO);
+    assert_eq!(back_hi.to_array(), F32X8_HI);
+}
+
+#[cfg(feature = "w512")]
+fn reverse_roundtrip_f32x16<T: F32x16FromHalves>(token: T) {
+    let mut original_lanes = [0f32; 16];
+    original_lanes[..8].copy_from_slice(&F32X8_LO);
+    original_lanes[8..].copy_from_slice(&F32X8_HI);
+    let original = f32x16::<T>::from_array(token, original_lanes);
+    let (lo, hi) = original.split();
+    let rebuilt = f32x16::<T>::from_halves(token, lo, hi);
+    assert_eq!(rebuilt.to_array(), original_lanes);
+}
+
+#[cfg(feature = "w512")]
+fn parity_with_scalar_f32x16<T: F32x16FromHalves>(token: T) {
+    let scalar_token = ScalarToken::summon().unwrap();
+    let lo_t = f32x8::<T>::from_array(token, F32X8_LO);
+    let hi_t = f32x8::<T>::from_array(token, F32X8_HI);
+    let lo_s = f32x8::<ScalarToken>::from_array(scalar_token, F32X8_LO);
+    let hi_s = f32x8::<ScalarToken>::from_array(scalar_token, F32X8_HI);
+    let wide_t = f32x16::<T>::from_halves(token, lo_t, hi_t);
+    let wide_s = f32x16::<ScalarToken>::from_halves(scalar_token, lo_s, hi_s);
+    assert_eq!(wide_t.to_array(), wide_s.to_array());
+    assert_eq!(wide_t.low().to_array(), wide_s.low().to_array());
+    assert_eq!(wide_t.high().to_array(), wide_s.high().to_array());
+}
+
+// ============================================================================
+// Per-token instantiation — every backend exercised on every supported host
+// ============================================================================
+
+#[test]
+fn scalar_w128_w256() {
+    let t = ScalarToken::summon().expect("scalar always available");
+    lane_order_f32x8(t);
+    roundtrip_f32x8(t);
+    reverse_roundtrip_f32x8(t);
+    parity_with_scalar_f32x8(t);
+}
+
+#[cfg(feature = "w512")]
+#[test]
+fn scalar_w256_w512() {
+    let t = ScalarToken::summon().unwrap();
+    lane_order_f32x16(t);
+    roundtrip_f32x16(t);
+    reverse_roundtrip_f32x16(t);
+    parity_with_scalar_f32x16(t);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn x64v3_w128_w256() {
+    if let Some(t) = archmage::X64V3Token::summon() {
+        lane_order_f32x8(t);
+        roundtrip_f32x8(t);
+        reverse_roundtrip_f32x8(t);
+        parity_with_scalar_f32x8(t);
+    } else {
+        eprintln!("X64V3Token not available — skipping");
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "w512"))]
+#[test]
+fn x64v3_w256_w512_polyfilled() {
+    // f32x16<X64V3Token> polyfills to [__m256; 2] — exercise the polyfill path.
+    if let Some(t) = archmage::X64V3Token::summon() {
+        lane_order_f32x16(t);
+        roundtrip_f32x16(t);
+        reverse_roundtrip_f32x16(t);
+        parity_with_scalar_f32x16(t);
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+#[test]
+fn x64v4_w128_w256_via_v3_delegation() {
+    // Exercises the V4-delegated F32x4 / F32x8 backends — same machinery as V3.
+    if let Some(t) = archmage::X64V4Token::summon() {
+        lane_order_f32x8(t);
+        roundtrip_f32x8(t);
+        reverse_roundtrip_f32x8(t);
+        parity_with_scalar_f32x8(t);
+    } else {
+        eprintln!("X64V4Token not available — skipping");
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "avx512", feature = "w512"))]
+#[test]
+fn x64v4_w256_w512_native() {
+    // f32x16<X64V4Token> uses native __m512 + _mm512_insertf32x8 — distinct
+    // from V3's polyfill path. Parity with Scalar (and V3) MUST hold.
+    if let Some(t) = archmage::X64V4Token::summon() {
+        lane_order_f32x16(t);
+        roundtrip_f32x16(t);
+        reverse_roundtrip_f32x16(t);
+        parity_with_scalar_f32x16(t);
+    }
+}
+
+/// **Critical regression test**: V4's native AVX-512 `_mm512_insertf32x8`
+/// path must produce the same lane assignment as V3's polyfilled
+/// `[__m256; 2]` path. If V4 is using imm=0 instead of imm=1 (or any
+/// other lane mistake), this will catch it.
+#[cfg(all(target_arch = "x86_64", feature = "avx512", feature = "w512"))]
+#[test]
+fn v4_native_matches_v3_polyfill() {
+    let v4 = match archmage::X64V4Token::summon() {
+        Some(t) => t,
+        None => return,
+    };
+    let v3 = archmage::X64V3Token::summon().expect("V4 implies V3");
+
+    let lo_v4 = f32x8::<archmage::X64V4Token>::from_array(v4, F32X8_LO);
+    let hi_v4 = f32x8::<archmage::X64V4Token>::from_array(v4, F32X8_HI);
+    let wide_v4 = f32x16::<archmage::X64V4Token>::from_halves(v4, lo_v4, hi_v4);
+
+    let lo_v3 = f32x8::<archmage::X64V3Token>::from_array(v3, F32X8_LO);
+    let hi_v3 = f32x8::<archmage::X64V3Token>::from_array(v3, F32X8_HI);
+    let wide_v3 = f32x16::<archmage::X64V3Token>::from_halves(v3, lo_v3, hi_v3);
+
+    assert_eq!(
+        wide_v4.to_array(),
+        wide_v3.to_array(),
+        "V4 native path disagrees with V3 polyfill"
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn neon_w128_w256() {
+    if let Some(t) = archmage::NeonToken::summon() {
+        lane_order_f32x8(t);
+        roundtrip_f32x8(t);
+        reverse_roundtrip_f32x8(t);
+        parity_with_scalar_f32x8(t);
+    }
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "w512"))]
+#[test]
+fn neon_w256_w512_cascade_polyfill() {
+    if let Some(t) = archmage::NeonToken::summon() {
+        lane_order_f32x16(t);
+        roundtrip_f32x16(t);
+        reverse_roundtrip_f32x16(t);
+        parity_with_scalar_f32x16(t);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[test]
+fn wasm128_w128_w256() {
+    if let Some(t) = archmage::Wasm128Token::summon() {
+        lane_order_f32x8(t);
+        roundtrip_f32x8(t);
+        reverse_roundtrip_f32x8(t);
+        parity_with_scalar_f32x8(t);
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "w512"))]
+#[test]
+fn wasm128_w256_w512_cascade_polyfill() {
+    if let Some(t) = archmage::Wasm128Token::summon() {
+        lane_order_f32x16(t);
+        roundtrip_f32x16(t);
+        reverse_roundtrip_f32x16(t);
+        parity_with_scalar_f32x16(t);
+    }
+}
+
+// ============================================================================
+// Adversarial: bit-precise edge values
+// ============================================================================
+
+const EDGE_LANES_4: [f32; 4] = [
+    f32::NAN,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    f32::MIN_POSITIVE,
+];
+const EDGE_LANES_4B: [f32; 4] = [-0.0, f32::EPSILON, f32::MAX, f32::MIN];
+
+/// `from_halves` MUST be a pure bit-shuffle — it must not normalize NaN
+/// payloads, flush denormals, or otherwise transform lane bits. Verify
+/// every lane survives the round-trip bitwise.
+fn bitwise_round_trip_f32x8<T: F32x8FromHalves>(token: T) {
+    let lo = f32x4::<T>::from_array(token, EDGE_LANES_4);
+    let hi = f32x4::<T>::from_array(token, EDGE_LANES_4B);
+    let wide = f32x8::<T>::from_halves(token, lo, hi);
+    let arr = wide.to_array();
+    for i in 0..4 {
+        assert_eq!(
+            arr[i].to_bits(),
+            EDGE_LANES_4[i].to_bits(),
+            "lo lane {i} bits changed"
+        );
+    }
+    for i in 0..4 {
+        assert_eq!(
+            arr[4 + i].to_bits(),
+            EDGE_LANES_4B[i].to_bits(),
+            "hi lane {i} bits changed"
+        );
+    }
+}
+
+#[test]
+fn scalar_bit_precise() {
+    bitwise_round_trip_f32x8(ScalarToken::summon().unwrap());
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn x64v3_bit_precise() {
+    if let Some(t) = archmage::X64V3Token::summon() {
+        bitwise_round_trip_f32x8(t);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn neon_bit_precise() {
+    if let Some(t) = archmage::NeonToken::summon() {
+        bitwise_round_trip_f32x8(t);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[test]
+fn wasm128_bit_precise() {
+    if let Some(t) = archmage::Wasm128Token::summon() {
+        bitwise_round_trip_f32x8(t);
+    }
+}
+
+// ============================================================================
+// Idempotency: re-extracting halves twice yields identical results
+// ============================================================================
+
+fn idempotent_extraction_f32x8<T: F32x8FromHalves>(token: T) {
+    let wide = f32x8::<T>::from_array(token, F32X8_LO);
+    assert_eq!(wide.low().to_array(), wide.low().to_array());
+    assert_eq!(wide.high().to_array(), wide.high().to_array());
+    let (a_lo, a_hi) = wide.split();
+    let (b_lo, b_hi) = wide.split();
+    assert_eq!(a_lo.to_array(), b_lo.to_array());
+    assert_eq!(a_hi.to_array(), b_hi.to_array());
+}
+
+#[test]
+fn scalar_idempotent() {
+    idempotent_extraction_f32x8(ScalarToken::summon().unwrap());
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn x64v3_idempotent() {
+    if let Some(t) = archmage::X64V3Token::summon() {
+        idempotent_extraction_f32x8(t);
+    }
+}
+
+// ============================================================================
+// Many-permutation lane-shuffle test (random-ish but deterministic)
+// ============================================================================
+
+/// Build a lookup from lane index in the wide vector to its expected source
+/// lane in (lo, hi). Detect any silent reorder.
+fn permutation_test_f32x8<T: F32x8FromHalves>(token: T) {
+    for seed in 0u32..16 {
+        let mut lo = [0f32; 4];
+        let mut hi = [0f32; 4];
+        for i in 0..4 {
+            lo[i] = f32::from_bits(0x4000_0000 | (seed << 16) | (i as u32));
+            hi[i] = f32::from_bits(0x4080_0000 | (seed << 16) | (i as u32));
+        }
+        let lo_v = f32x4::<T>::from_array(token, lo);
+        let hi_v = f32x4::<T>::from_array(token, hi);
+        let wide = f32x8::<T>::from_halves(token, lo_v, hi_v).to_array();
+        for i in 0..4 {
+            assert_eq!(
+                wide[i].to_bits(),
+                lo[i].to_bits(),
+                "lo lane {i} (seed {seed})"
+            );
+            assert_eq!(
+                wide[4 + i].to_bits(),
+                hi[i].to_bits(),
+                "hi lane {i} (seed {seed})"
+            );
+        }
+    }
+}
+
+#[test]
+fn scalar_permutations() {
+    permutation_test_f32x8(ScalarToken::summon().unwrap());
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn x64v3_permutations() {
+    if let Some(t) = archmage::X64V3Token::summon() {
+        permutation_test_f32x8(t);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn neon_permutations() {
+    if let Some(t) = archmage::NeonToken::summon() {
+        permutation_test_f32x8(t);
+    }
+}
+
+// Suppress unused-const warnings for tests that don't reference every constant.
+#[allow(dead_code)]
+const _USES: [&[f32]; 2] = [&F32X4_C, &F32X4_D];

--- a/xtask/src/simd_types/backend_gen.rs
+++ b/xtask/src/simd_types/backend_gen.rs
@@ -933,6 +933,11 @@ fn generate_impls_mod() -> String {
         #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
         mod x86_v4;
 
+        // V4-family delegation of W128 / W256 f32 backends to V3 (hand-written —
+        // future generators may take it over). V4 ⊃ V3, so delegating is sound.
+        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        mod x86_v4_f32_delegated;
+
         #[cfg(target_arch = "aarch64")]
         mod arm_neon;
 


### PR DESCRIPTION
**Replaces #37.** That one was scoped to f32x4↔f32x8 on 4 tokens; this is the deductively-proven full f32 chain.

## What it does

Generic `from_halves` / `low` / `high` / `split` for the two adjacent f32 width pairs across every backend that has both adjacent widths' backends:

- **f32x4 ↔ f32x8** (W128↔W256): Scalar, NEON, Wasm128, X64V3Token, X64V4Token (5 impls)
- **f32x8 ↔ f32x16** (W256↔W512): Scalar, NEON, Wasm128, X64V3Token, X64V4Token (5 impls; not Avx512Fp16Token because Fp16 has no F32x16Backend on origin/main)

Native intrinsics where wider features exist; polyfill (zero-cost array construction) where they don't:

| Pair | Token | Wider Repr | Op emitted |
|---|---|---|---|
| f32x4→f32x8 | V3 / V4 | `__m256` | `vinsertf128` (native AVX) |
| f32x8→f32x16 | V3 | `[__m256;2]` | `[lo, hi]` (polyfill) |
| f32x8→f32x16 | V4 / V4x | `__m512` | `vinsertf32x8` (native AVX-512) |
| any | NEON / Wasm128 | `[Repr; N]` | array (zero-cost) |
| any | Scalar | `[f32; N]` | array concat |

## V4 narrower-width backends added

`X64V4Token` had only `F32x16Backend`. Without `F32x4Backend` / `F32x8Backend`, generic code on the narrower widths couldn't accept a V4 token, and the cross-width primitive couldn't reach V4 at all. New `magetypes/src/simd/impls/x86_v4_f32_delegated.rs` provides those, delegating each method to `X64V3Token`'s impl. Sound by **V3 ⊊ V4** (proof in module doc); Repr stays `__m128` / `__m256` so callers see no representation change. V4 token + delegated narrower backends + `_mm512_insertf32x8` on the wider end = native AVX-512 raise from any V4 context.

## Deductive safety

Every impl carries a per-backend safety proof spelled out in source (module doc + per-impl comments). The general structure:

1. Token type only constructible via `T::summon()` (runtime feature detect) or upgrade extractors. `forge_token_dangerously` is `unsafe` and explicitly out of the soundness chain.
2. Each intrinsic's required target features are a subset of what the relevant token guarantees (Intel SDM citations inline).
3. `f32x{4,8,16}<T>` are `#[repr(transparent)]` over `T::Repr`, so the wrapping in `from_repr_unchecked` is layout-safe.

## Adversarial tests (`tests/cross_width_adversarial.rs`, 13 tests)

- **Lane order**: every backend MUST place `lo[0..N]` in the low half. Catches lane-shuffle.
- **Round-trip & reverse round-trip**: bit-identical idempotency in both directions.
- **Cross-backend parity**: every token's output bit-equals Scalar's output for the same inputs.
- **`v4_native_matches_v3_polyfill`**: AVX-512 path's lane assignment MUST equal V3's polyfill. Catches `imm=0` vs `imm=1` regressions and any other lane mistake in the V4 native intrinsic path.
- **Bit-precise**: NaN payloads, ±0.0, ±∞, denormals survive every round-trip bit-identical.
- **Permutation sweep**: 16 different lane fingerprints, verified bit-by-bit.
- **Idempotency**: repeated `low()` / `split()` calls produce identical results.

All pass on x86_64 stable, x86_64 with `--features avx512` (V4 paths exercised on real hardware), aarch64-linux (cross-check), wasm32 (cross-check).

## Codegen change

`from_repr_unchecked` is now `pub(crate)` (was `pub(super)`). Callers in `simd::generic::*` need to wrap a narrower repr without re-supplying a token; the wider input type already proves `T`, so the wrap is sound. One line in `xtask/src/simd_types/generic_gen/type_impl.rs`; regenerated 30 files.

## Out of scope (deferred follow-ups)

- f64 / int / unsigned chains: same template.
- The `Avx512Fp16Token` F32x16FromHalves impl: needs `F32x16Backend` for Fp16 first.

## Heads up

Pre-existing `archmage-macros` clippy failures from rustc 1.95 lint additions (`unnecessary_sort_by`) and pre-existing trybuild ui_test snapshot drift (`autoversion_concrete_token.stderr`) will both fire on this PR's CI. Both reproduce on `origin/main` clean, unrelated to this branch — separate cleanup PRs needed.

## Test plan

- [x] `cargo test -p magetypes --test cross_width_adversarial` (10 tests pass on x86_64 stable)
- [x] `cargo test -p magetypes --features avx512 --test cross_width_adversarial` (13 tests pass; V4 paths exercised on AVX-512 host)
- [x] `cargo test --lib`
- [x] `cargo check --target aarch64-unknown-linux-gnu`
- [x] `cargo check --target wasm32-unknown-unknown`
- [x] `cargo run -p xtask -- generate`
- [ ] CI on `windows-11-arm` runner — verify NEON cascade polyfill on real Cobalt 100 hardware
- [ ] CI on `ubuntu-24.04-arm` — same
- [ ] WASM CI job — Wasm128 cascade polyfill
- [ ] AVX-512-capable CI runner — verify `v4_native_matches_v3_polyfill` on real hardware
- [ ] Downstream: moxcms `magetypes-refactor` — Double-variant interpolators delete their hand-written AVX/NEON impls