### PR TITLE
draft: artisan-macros — auditable SIMD dispatch proc-macros

### DIFF
--- a/.github/workflows/artisan-macros.yml
+++ b/.github/workflows/artisan-macros.yml
@@ -151,19 +151,21 @@ jobs:
           workspaces: artisan-macros -> target
 
       - name: Install cargo-expand
-        run: cargo install cargo-expand --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand
 
       - name: Run macrotest expand
-        run: cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --test expand
+        run: cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --features run_expand_test --test expand
 
       - name: Fail if snapshots would change
         shell: bash
         run: |
           set +e
-          MACROTEST=overwrite cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --test expand
+          MACROTEST=overwrite cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --features run_expand_test --test expand
           if ! git diff --exit-code -- artisan-macros/tests/expand/; then
             echo "::error::expansion snapshots are out of date."
-            echo "::error::Regenerate locally with: MACROTEST=overwrite cargo test -p artisan-macros --test expand"
+            echo "::error::Regenerate locally with: MACROTEST=overwrite cargo test -p artisan-macros --features run_expand_test --test expand"
             echo "::error::Then commit the updated *.expanded.rs files."
             exit 1
           fi

--- a/.github/workflows/artisan-macros.yml
+++ b/.github/workflows/artisan-macros.yml
@@ -1,0 +1,235 @@
+name: artisan-macros
+
+# Dedicated CI for the artisan-macros crate. Runs only when artisan-macros or
+# its workflow change, so archmage's much larger CI doesn't double-run on
+# unrelated commits.
+#
+# Status: draft. Matrix mirrors archmage's own CI standards (x64 Linux +
+# Windows + macOS Intel, ARM64 Linux + Windows, 32-bit Linux via cross).
+# Windows ARM64 (windows-11-arm) added per the imazen global rule that every
+# crate must CI-test there.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'artisan-macros/**'
+      - '.github/workflows/artisan-macros.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'artisan-macros/**'
+      - '.github/workflows/artisan-macros.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CI: true
+
+jobs:
+  # ==========================================================================
+  # Native x64 + ARM64 testing across OSes.
+  # ==========================================================================
+  test-native:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - windows-11-arm
+          - macos-26-intel
+          - macos-latest   # aarch64 macOS (Apple Silicon)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: artisan-macros -> target
+
+      - name: Build
+        run: cargo build -p artisan-macros --manifest-path artisan-macros/Cargo.toml
+
+      - name: Test
+        run: cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml
+
+      - name: Test with test-hooks feature
+        run: cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --features artisan_test_hooks
+
+  # ==========================================================================
+  # Cross-compiled targets (32-bit + ARM).
+  # ==========================================================================
+  test-cross:
+    name: Cross (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: artisan-macros -> target
+
+      - name: Build (cross)
+        run: cross build -p artisan-macros --manifest-path artisan-macros/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Test (cross / QEMU)
+        run: cross test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --target ${{ matrix.target }}
+
+  # ==========================================================================
+  # Lint + formatting + docs.
+  # ==========================================================================
+  lint:
+    name: clippy / fmt / docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: artisan-macros -> target
+
+      - name: Check formatting
+        run: cargo fmt -p artisan-macros --manifest-path artisan-macros/Cargo.toml -- --check
+
+      - name: Clippy
+        run: cargo clippy -p artisan-macros --manifest-path artisan-macros/Cargo.toml --all-targets -- -D warnings
+
+      - name: Clippy (with test-hooks feature)
+        run: cargo clippy -p artisan-macros --manifest-path artisan-macros/Cargo.toml --all-targets --features artisan_test_hooks -- -D warnings
+
+      - name: Docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p artisan-macros --manifest-path artisan-macros/Cargo.toml --no-deps
+
+  # ==========================================================================
+  # Committed macro-expansion snapshot tests (macrotest + cargo-expand).
+  # Catches any drift between the proc-macro output and the committed
+  # tests/expand/*.expanded.rs files. Snapshots are x86_64-resolved (cargo
+  # expand strips non-host cfg branches), so this job only runs there.
+  # ==========================================================================
+  expand-snapshots:
+    name: Macro expansion snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: artisan-macros -> target
+
+      - name: Install cargo-expand
+        run: cargo install cargo-expand --locked
+
+      - name: Run macrotest expand
+        run: cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --test expand
+
+      - name: Fail if snapshots would change
+        shell: bash
+        run: |
+          set +e
+          MACROTEST=overwrite cargo test -p artisan-macros --manifest-path artisan-macros/Cargo.toml --test expand
+          if ! git diff --exit-code -- artisan-macros/tests/expand/; then
+            echo "::error::expansion snapshots are out of date."
+            echo "::error::Regenerate locally with: MACROTEST=overwrite cargo test -p artisan-macros --test expand"
+            echo "::error::Then commit the updated *.expanded.rs files."
+            exit 1
+          fi
+
+  # ==========================================================================
+  # Deliberate mismatch test: verify the feature-string compile-time check
+  # actually catches a mismatched declaration. Uses a shell heredoc to write
+  # a minimal test crate, expect-failures the build, and asserts the error
+  # mentions "feature-string mismatch".
+  # ==========================================================================
+  feature-mismatch-catches:
+    name: Feature-string mismatch is caught
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: artisan-macros -> target
+
+      - name: Build artisan-macros first (populate the lockfile)
+        run: cargo build -p artisan-macros --manifest-path artisan-macros/Cargo.toml
+
+      - name: Write deliberately-mismatched crate
+        shell: bash
+        run: |
+          mkdir -p /tmp/mismatch-test/src
+          cat > /tmp/mismatch-test/Cargo.toml <<'EOF'
+          [package]
+          name = "mismatch-test"
+          version = "0.0.0"
+          edition = "2024"
+          [dependencies]
+          artisan-macros = { path = "ARTISAN_PATH" }
+          EOF
+          sed -i "s|ARTISAN_PATH|$PWD/artisan-macros|" /tmp/mismatch-test/Cargo.toml
+          cat > /tmp/mismatch-test/src/lib.rs <<'EOF'
+          use artisan_macros::{cpu_tier, chain};
+          fn scalar(a: &[f32]) -> f32 { a.iter().sum() }
+          #[cpu_tier(enable = "avx2,fma")]
+          fn v3(a: &[f32]) -> f32 { a.iter().sum() }
+          // DELIBERATE mismatch: chain says bmi2, cpu_tier doesn't.
+          #[chain(
+              x86_64 = [v3 = "avx2,fma,bmi2"],
+              default = scalar,
+          )]
+          pub fn run(a: &[f32]) -> f32 {}
+          EOF
+
+      - name: Expect build to fail with clear error
+        shell: bash
+        run: |
+          set +e
+          output=$(cargo build --manifest-path /tmp/mismatch-test/Cargo.toml 2>&1)
+          status=$?
+          echo "$output"
+          if [ $status -eq 0 ]; then
+            echo "::error::mismatch test compiled successfully; feature-string check is not firing"
+            exit 1
+          fi
+          if ! echo "$output" | grep -q "feature-string mismatch"; then
+            echo "::error::mismatch test failed, but error does not mention 'feature-string mismatch'"
+            exit 1
+          fi
+          echo "mismatch correctly detected"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "artisan-macros"
+version = "0.0.0"
+dependencies = [
+ "macrotest",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "archmage-macros", "magetypes", "xtask", "tests/no-features-crate"]
+members = [".", "archmage-macros", "artisan-macros", "magetypes", "xtask", "tests/no-features-crate"]
 
 [workspace.package]
 version = "0.9.20"

--- a/artisan-macros/ARCHMAGE-THREAD-LOCAL-ISSUE.md
+++ b/artisan-macros/ARCHMAGE-THREAD-LOCAL-ISSUE.md
@@ -1,0 +1,107 @@
+# GitHub issue draft: add thread-local override layer to archmage token caches
+
+**Status:** draft, pending review. Intended target: https://github.com/imazen/archmage/issues
+
+---
+
+## Title
+
+Add thread-local override layer to token caches (prerequisite for cross-tier parity harness)
+
+## Body
+
+## Problem
+
+`archmage::dangerously_disable_token_process_wide()` writes to the process-wide atomic cache of a token. Under parallel test execution (cargo's default), two tests that both disable different tokens race — thread A sees thread B's disabled state mid-test, and vice versa. This makes the API effectively unusable for testing tier fallbacks in a crate that runs more than a handful of tests in parallel.
+
+The proposed cross-tier parity harness (#TBD) needs to downgrade tier selection per-test, reliably, without `#[serial]` annotations or `RUST_TEST_THREADS=1`. Without a thread-local override, the harness has no way to isolate parity tests from each other when they force different max tiers.
+
+## Proposal
+
+Add a thread-local override layer on top of every token's atomic cache. The atomic cache remains the source of truth for CPU detection (and continues to use `Relaxed` ordering with idempotent writes). The thread-local is an orthogonal downgrade override.
+
+Each token `T` gains a generated thread-local boolean ("is this token disabled on the current thread?"). `T::summon()` consults the thread-local after its compile-time `#[cfg(target_feature)]` check and before the atomic cache. If the thread-local says "disabled," `summon()` returns `None` without touching the cache.
+
+`dangerously_disable_token_process_wide` is kept as-is for backwards compatibility (and for the genuine use case of disabling a token across a rayon pool), but it is renamed in docs to something like "process-wide forcing — not for parallel tests; see `force_token_disabled` for per-test scoping."
+
+## API shape
+
+```rust
+// NEW: thread-local, RAII-scoped, per-test.
+pub fn force_token_disabled<T: SimdToken>() -> TokenScope<T>;
+
+#[must_use = "dropping restores the previous setting"]
+pub struct TokenScope<T> { /* opaque */ }
+
+impl<T: SimdToken> Drop for TokenScope<T> {
+    fn drop(&mut self) { /* restore previous thread-local state */ }
+}
+
+// EXISTING: unchanged, but doc-steered away from tests.
+pub fn dangerously_disable_token_process_wide<T: SimdToken>(disabled: bool);
+```
+
+Codegen change in `xtask/src/token_gen.rs`:
+
+```rust
+// Emitted alongside the existing atomic cache per token:
+thread_local! {
+    static FORCED_DISABLED: Cell<bool> = const { Cell::new(false) };
+}
+```
+
+`T::summon()` modified to consult the thread-local:
+
+```rust
+impl SimdToken for T {
+    fn summon() -> Option<Self> {
+        // compile-time fast path (unchanged)
+        if let Some(b) = Self::compiled_with() {
+            return if b { Some(unsafe { Self::forge_token_dangerously() }) } else { None };
+        }
+        // NEW: thread-local override
+        if FORCED_DISABLED.with(|c| c.get()) {
+            return None;
+        }
+        // atomic cache path (unchanged)
+        match CACHE.load(Relaxed) {
+            2 => Some(unsafe { Self::forge_token_dangerously() }),
+            1 => None,
+            _ => { /* run detection + store + return */ }
+        }
+    }
+}
+```
+
+## Soundness
+
+The thread-local can only DISABLE a token, never fabricate one. Disabling a token the CPU supports cannot cause UB — the code path takes a slower variant. Fabricating a token the CPU lacks would SIGILL; the API does not expose that direction.
+
+All existing sanity properties are preserved:
+
+- Constant-CPUID axiom still holds. CPU features don't change; the cache is still a memoisation of a pure function.
+- Cache values `0/1/2` remain correct; the thread-local is an orthogonal override.
+- Downstream `#![forbid(unsafe_code)]` unaffected — thread-local machinery is all safe code.
+
+## Migration
+
+- `dangerously_disable_token_process_wide` stays. Existing callers keep working.
+- Documentation adds a section pointing tests toward `force_token_disabled` and reserving the process-wide function for rayon-pool use cases and infrastructure tests in `archmage`'s own test suite.
+- The cross-tier parity harness (when implemented) uses only `force_token_disabled`.
+
+## Testing
+
+- Unit test: `force_token_disabled::<X64V3Token>()` on thread A doesn't affect `X64V3Token::summon()` on thread B (spawn two threads, verify).
+- Unit test: RAII restoration — after scope drop, `summon()` returns the real CPU state.
+- Unit test: nested scopes compose correctly.
+- Integration test: two parallel `#[test]` functions each force different tokens disabled and verify no interference. This test is the whole point of the refactor.
+
+## Scope
+
+This issue covers the thread-local override layer. The cross-tier parity harness that builds on it is a separate tracking issue (#TBD parity-harness).
+
+## Open questions
+
+- **Name of the new API.** `force_token_disabled` matches the existing `dangerously_disable_token_process_wide` shape. Alternatives: `scoped_disable_token`, `with_token_disabled`, `disable_token_scoped`. No strong preference; whichever matches archmage's naming conventions.
+- **Per-token vs per-tier thread-locals.** Current proposal: one thread-local per token. An alternative is a single tier-indexed thread-local (matching the artisan-macros design). Per-token is more aligned with archmage's existing code-gen; per-tier would be a larger refactor.
+- **`for_each_token_permutation` compatibility.** The existing iteration test helper uses process-wide disabling. If the helper runs on a single thread, it can use the new scoped API; if it spawns threads, it needs the process-wide version. Decide per helper.

--- a/artisan-macros/Cargo.toml
+++ b/artisan-macros/Cargo.toml
@@ -20,6 +20,13 @@ proc-macro = true
 # the #[chain] declaration.
 artisan_test_hooks = []
 
+# Gate for the macrotest expansion-snapshot integration test. The test shells
+# out to `cargo expand`, which isn't installed in every CI job. Enabling this
+# feature turns the test on; default `cargo test` omits it entirely, so non-
+# expand CI jobs don't pay the cargo-expand install cost. The dedicated
+# expand-snapshots CI job runs with this feature on.
+run_expand_test = []
+
 [dependencies]
 syn = { version = "2.0.0", features = ["full", "parsing", "printing"] }
 quote = "1.0.0"
@@ -27,6 +34,15 @@ proc-macro2 = "1.0.0"
 
 [dev-dependencies]
 # Committed macro-expansion snapshots. Regenerate with `MACROTEST=overwrite
-# cargo test -p artisan-macros --test expand` and commit the updated
-# `*.expanded.rs` files next to their inputs in `tests/expand/`.
+# cargo test -p artisan-macros --features run_expand_test --test expand`
+# and commit the updated `*.expanded.rs` files next to their inputs in
+# `tests/expand/`.
 macrotest = "1.2.1"
+
+# Built only when run_expand_test is enabled; otherwise Cargo skips the whole
+# test target (no compilation, no warnings on non-x86 hosts). See the feature
+# definition above for the rationale.
+[[test]]
+name = "expand"
+path = "tests/expand.rs"
+required-features = ["run_expand_test"]

--- a/artisan-macros/Cargo.toml
+++ b/artisan-macros/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "artisan-macros"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.89"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/imazen/archmage"
+description = "Auditable, convention-forward proc-macros for sound SIMD tier dispatch. Trampolines recurse into downgrades; users own feature strings and suffixes."
+keywords = ["simd", "dispatch", "target-feature", "macro"]
+categories = ["development-tools::procedural-macro-helpers", "hardware-support"]
+publish = false
+
+[lib]
+proc-macro = true
+
+[features]
+# Expose the thread-local force_max_tier test-hook API from generated code.
+# Unit tests inside the declaring crate get hooks automatically via cfg(test);
+# downstream integration tests need this feature flag on the crate that owns
+# the #[chain] declaration.
+artisan_test_hooks = []
+
+[dependencies]
+syn = { version = "2.0.0", features = ["full", "parsing", "printing"] }
+quote = "1.0.0"
+proc-macro2 = "1.0.0"
+
+[dev-dependencies]
+# Committed macro-expansion snapshots. Regenerate with `MACROTEST=overwrite
+# cargo test -p artisan-macros --test expand` and commit the updated
+# `*.expanded.rs` files next to their inputs in `tests/expand/`.
+macrotest = "1.2.1"

--- a/artisan-macros/DESIGN.md
+++ b/artisan-macros/DESIGN.md
@@ -1,0 +1,293 @@
+# artisan-macros design
+
+Auditable, convention-forward proc-macros for sound SIMD tier dispatch.
+
+The entire crate is intended to be readable top-to-bottom in a single sitting. Nothing is hidden behind a TOML registry, an xtask codegen step, or a body-walking rewriter. Users own the feature strings and suffixes; the macros only wire up the attributes and the dispatch chain.
+
+## Goals
+
+1. **Sound by construction** — every `unsafe { }` emitted is co-located with the CPUID check that justifies it, inside the macro's own definition span.
+2. **`#![forbid(unsafe_code)]`-compatible downstream** — `unsafe` tokens in the expansion trace to this crate, not the user's.
+3. **Auditable** — the proc-macro code fits in a single file, with expansion shapes documented inline. No cross-file indirection.
+4. **Convention-forward** — explicit over clever. No auto-inference of features from suffixes, no hidden tier registry, no body cloning with placeholder tokens. What you write is what runs.
+5. **Zero runtime dependency** — expansions reference only `core::sync::atomic` and the stdlib feature-detection macros.
+
+## Non-goals
+
+- Token-as-proof type system (archmage owns that layer)
+- Body-level rewriting or placeholder substitution (archmage's `incant!` / `#[magetypes]`)
+- Scalar auto-vectorization cloning (archmage's `#[autoversion]`)
+- A built-in tier registry with LLVM microarchitecture levels baked in
+
+If you need any of the above, use archmage. This crate is for users who want the smallest possible dispatch surface they can read, own, and fork.
+
+## The trampoline-chain model
+
+Per-call-site dispatch trees are replaced by a *chain* of tier trampolines, where each trampoline's failure case is "recurse into the next-lower tier." The compile-time entry function is just an arch switch that calls the highest trampoline for the current architecture.
+
+```text
+compute(data)
+ └─ #[cfg(target_arch = "x86_64")] compute__chain_v3(data)
+     ├─ V3_CACHE hit-yes  → unsafe { compute_v3(data) }
+     ├─ V3_CACHE hit-no   → compute__chain_v2(data)
+     │                       ├─ V2_CACHE hit-yes → unsafe { compute_v2(data) }
+     │                       ├─ V2_CACHE hit-no  → compute_scalar(data)
+     │                       └─ V2_CACHE empty   → detect+store, then yes/no arm
+     └─ V3_CACHE empty    → detect+store, then yes/no arm
+```
+
+Every chain bottom-out is the user-supplied `default` / scalar function. There is no separate dispatcher fn at the call site; the chain IS the dispatcher.
+
+### Why this shape
+
+- **Call sites are a single function call.** Inlining and devirtualization happen naturally.
+- **Compile-time elision is trivial.** The entry fn body is `#[cfg(target_feature = "avx2,fma,...")] { return unsafe { compute_v3(data) }; }` before the runtime chain — when the ambient target covers a tier, the runtime chain is dead code.
+- **Each trampoline reads as one unit.** Cache check, one detect-and-store arm, two terminal arms. ~12 lines expanded per tier, same shape every time.
+- **Adding a tier is local.** You insert a new trampoline in the chain; no other dispatch site changes.
+- **Removing a tier is local.** Delete the trampoline, wire its predecessor to the next one down. Nothing else moves.
+
+## Tri-state cache, one per feature set
+
+Each tier in the chain gets an `AtomicU8` cache. Values:
+
+| Value | Meaning |
+|---|---|
+| `0` | Empty — feature detection has not run yet |
+| `1` | False — CPU does NOT have this feature set |
+| `2` | True — CPU has this feature set |
+
+The cache is **per feature set**, not per tier name. If two tiers in the same crate happen to have identical feature strings (rare but legal), they share a cache via a deterministic name mangle. This is the only codegen cleverness in the crate and it's explicit.
+
+### Soundness of the cache
+
+- **Constant-CPUID axiom** — on tier-1 Rust targets, CPU features do not change during process lifetime. The cache memoizes a pure function. Relaxed atomic ordering is correct because the value is idempotent — racing stores write the same bits.
+- **No safe API to fabricate "true."** The public test-hooks API can only write `1` (force-unavailable), never `2` (force-available). Fabricating availability would call an intrinsic on a CPU that can't execute it — SIGILL. Disabling a tier is always sound.
+- **No visible initialization ordering.** The cache is inside the macro expansion, private to the function. Callers cannot observe the transition from `0` to `1`/`2`.
+
+## `#[cpu_tier]` — thin target_feature wrapper
+
+```rust
+#[cpu_tier(enable = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe")]
+fn compute_v3(data: &[f32]) -> f32 {
+    // hand-written AVX2+FMA body
+}
+```
+
+Expands to:
+
+```rust
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe")]
+#[inline]
+fn compute_v3(data: &[f32]) -> f32 {
+    // body unchanged
+}
+```
+
+That's it. No token parameter, no wrapper, no body inspection. The function is the user's; the macro only attaches attributes. The `#[target_feature]` function is `fn` (not `unsafe fn`) per the Rust 2024 edition rule — `#![forbid(unsafe_code)]`-compatible.
+
+**Arch inference is the default.** The macro scans the feature list for any unambiguous name (e.g., `avx2`, `avx512f`, `bmi2` → x86_64; `neon`, `dotprod`, `i8mm`, `sve` → aarch64; `simd128` → wasm32) and picks the matching `#[cfg(target_arch = "...")]`. Features that appear on multiple architectures (`aes`, `sha2`, `crc`) are ignored for inference — if every listed feature is ambiguous, inference fails with a clear compile error pointing at the user-supplied `arch = "..."` override. Inference failure is a compile error, not a silent default; ambiguity never ships a misinferred arch.
+
+The inference table is a `const` in the macro source, kept small by design. Users who want to disable inference entirely for a specific tier pass `arch = "x86_64"` explicitly.
+
+**No tier name baked in.** The `v3` is just the suffix on the function name, which is meaningful only to the `chain!` macro's reader. `compute_avx2_bmi2` would work equally well. Suffix conventions are the user's prerogative.
+
+## `#[chain]` — declare a trampoline chain
+
+`chain` is an attribute macro applied to a function with an empty body. The attribute supplies the per-arch tier lists with their feature strings inline; the macro discards the empty body and fills in the entry dispatcher.
+
+```rust
+#[chain(
+    x86_64 = [
+        compute_v3 = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe",
+        compute_v2 = "sse4.2,popcnt",
+    ],
+    aarch64 = [
+        compute_neon = "neon",
+    ],
+    wasm32 = [
+        compute_wasm128 = "simd128",
+    ],
+    default = compute_scalar,
+)]
+/// Public entry. Calls the highest-tier trampoline for the host arch.
+pub fn compute(data: &[f32]) -> f32 {}
+```
+
+The macro:
+
+1. Parses the attribute: each `arch = [ fn_name = "features", ... ]` list plus a single `default = fn_name` fallback.
+2. Parses the function signature (args, return type, visibility, doc attrs).
+3. Discards the empty `{}` body.
+4. Emits one trampoline per tier per arch, chained to its successor.
+5. Emits the entry function body with compile-time arch dispatch and compile-time feature-elision fast paths.
+6. Emits one `AtomicU8` cache per tier.
+
+Tier order in each arch list is **highest to lowest** — the first entry is tried first; cache-miss falls through to the next.
+
+### Feature-set resolution: inline at the chain site
+
+The feature string lives in two places: `#[cpu_tier(enable = "...")]` on the tier function, and `= "..."` inside the `#[chain]` list. Both must match. This is explicit and auditable — every feature string is visible at both the definition site (where the `#[target_feature]` gets attached) and the dispatch site (where the runtime detection happens).
+
+**Mismatch is a user bug, not a macro bug.** If `#[cpu_tier(enable = "avx2,fma")]` declares a narrower set than `#[chain(... compute_v3 = "avx2,fma,bmi2", ...)]`, the runtime check passes on a CPU that has AVX2+FMA but lacks BMI2, and the function runs — but only with AVX2+FMA enabled in `#[target_feature]`, so whatever BMI2 codegen LLVM would have used is absent. The converse (cpu_tier wider than chain) causes the reverse: LLVM may emit BMI2 instructions the detection check didn't verify, potentially SIGILL on CPUs that have AVX2+FMA but not BMI2.
+
+A future macro revision may emit a `const` from `#[cpu_tier]` and compile-time-assert equality from `#[chain]`, turning mismatches into compile errors. For now: two sites, one string, user copy-pastes.
+
+## Expansion shape
+
+For the call above, `#[chain]` emits approximately:
+
+```rust
+pub fn compute(data: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Compile-time elision: ambient target covers v3? jump straight in.
+        #[cfg(all(
+            target_feature = "avx2", target_feature = "fma", target_feature = "bmi1",
+            target_feature = "bmi2", target_feature = "f16c", target_feature = "lzcnt",
+            target_feature = "popcnt", target_feature = "movbe",
+        ))]
+        { return unsafe { compute_v3(data) }; }
+
+        #[cfg(not(all( /* v3 features */ )))]
+        { return compute__chain_v3(data); }
+    }
+    #[cfg(target_arch = "aarch64")]
+    { return compute__chain_neon(data); }
+    #[cfg(target_arch = "wasm32")]
+    { return compute__chain_wasm128(data); }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "wasm32")))]
+    { compute_scalar(data) }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn compute__chain_v3(data: &[f32]) -> f32 {
+    use core::sync::atomic::{AtomicU8, Ordering};
+    static CACHE: AtomicU8 = AtomicU8::new(0);
+    match CACHE.load(Ordering::Relaxed) {
+        2 => unsafe { compute_v3(data) },
+        1 => compute__chain_v2(data),
+        _ => {
+            let ok = std::is_x86_feature_detected!("avx2")
+                  && std::is_x86_feature_detected!("fma")
+                  && /* ... same features, splatted from the same const ... */;
+            CACHE.store(if ok { 2 } else { 1 }, Ordering::Relaxed);
+            if ok { unsafe { compute_v3(data) } } else { compute__chain_v2(data) }
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn compute__chain_v2(data: &[f32]) -> f32 { /* same shape, falls through to compute_scalar */ }
+
+// aarch64, wasm32 chains: analogous
+```
+
+Each trampoline: ~12 lines. Each `unsafe { }` block has the CPUID check 3 lines above it. Auditable by eye.
+
+## `#![forbid(unsafe_code)]` compatibility
+
+The `unsafe { }` blocks in the expansion originate from this crate's proc-macro definition spans. Downstream crates with `#![forbid(unsafe_code)]` accept them — the same exemption that archmage relies on for `#[arcane]`.
+
+The `#[target_feature]` function generated by `#[cpu_tier]` is declared `fn`, never `unsafe fn`. Rust 2024 allows this, and `#![forbid(unsafe_code)]` rejects `unsafe fn` declarations even from proc-macros.
+
+## Test hooks (feature-gated, thread-local)
+
+Behind `#[cfg(feature = "test-hooks")]`, each chain exposes a per-thread override layer on top of the (still-correct) atomic cache. The atomic cache continues to hold CPU truth; the thread-local is an orthogonal downgrade override visible only on the setting thread.
+
+```rust
+// Generated alongside each #[chain]-annotated fn `compute`:
+
+#[cfg(feature = "test-hooks")]
+pub enum ComputeTier { V3, V2, Neon, Default }  // variants from the user's fn suffixes
+
+#[cfg(feature = "test-hooks")]
+thread_local! {
+    static COMPUTE_FORCED_MAX_TIER: core::cell::Cell<Option<ComputeTier>>
+        = const { core::cell::Cell::new(None) };
+}
+
+#[cfg(feature = "test-hooks")]
+#[must_use = "dropping the scope immediately restores the previous override"]
+pub struct ComputeTierScope { prev: Option<ComputeTier> }
+
+#[cfg(feature = "test-hooks")]
+pub fn compute_force_max_tier(tier: ComputeTier) -> ComputeTierScope {
+    COMPUTE_FORCED_MAX_TIER.with(|c| {
+        let prev = c.replace(Some(tier));
+        ComputeTierScope { prev }
+    })
+}
+
+#[cfg(feature = "test-hooks")]
+impl Drop for ComputeTierScope {
+    fn drop(&mut self) {
+        COMPUTE_FORCED_MAX_TIER.with(|c| c.set(self.prev));
+    }
+}
+```
+
+Each trampoline consults the thread-local BEFORE its atomic cache:
+
+```rust
+fn compute__chain_v3(data: &[f32]) -> f32 {
+    #[cfg(feature = "test-hooks")]
+    if let Some(max) = COMPUTE_FORCED_MAX_TIER.with(|c| c.get()) {
+        if (max as u8) < (ComputeTier::V3 as u8) {
+            return compute__chain_v2(data);
+        }
+    }
+    // ...normal atomic-cache check...
+}
+```
+
+### Properties
+
+- **Per-thread isolation = per-test isolation.** Cargo runs one test per thread; forcing on thread A cannot affect thread B. No `#[serial]`, no `RUST_TEST_THREADS=1`, no race conditions between parity tests in the same crate.
+- **Zero cost in release.** The `#[cfg(feature = "test-hooks")]` block compiles away entirely. No branch on the hot path, no thread-local lookup, no `Option` check.
+- **RAII restore.** `ComputeTierScope` implements `Drop`. A panic during a test still unwinds the guard and restores the previous override. Tests cannot leak forced state.
+- **Nested overrides compose.** Calling `force_max_tier` inside a test that already has one set saves the outer value in `prev` and restores it on drop. Nested scopes nest correctly.
+- **Atomic cache stays correct.** The thread-local never writes to the cache. Production detection is unaffected; test hooks only overlay.
+
+### Rayon / worker-pool caveat
+
+`thread_local!` values do not propagate to rayon worker threads or any spawned thread. A test that calls `force_max_tier` on the main thread and then dispatches from a rayon `par_iter` sees the real-CPU behavior inside the worker, not the forced tier. This is a genuine limitation.
+
+Mitigations:
+
+- Use `serial_test::serial` on tests that dispatch across thread pools, and optionally expose a process-wide "force-max-tier" knob (separate API, clearly labelled). Not exposed by default — process-wide forcing is the thing we are deliberately avoiding.
+- Propagate the override manually by calling `force_max_tier` inside the rayon worker closure. Rayon's `scope` API makes this tolerable.
+
+In practice, parity harness tests are single-threaded (they call a function with an input and compare outputs). The rayon case is rare enough to doc-note rather than design around.
+
+### Comparison with archmage
+
+Archmage's `dangerously_disable_token_process_wide()` writes directly into the process-wide atomic cache, racing under parallel tests in the same way a naive artisan implementation would. Adding thread-local overrides to archmage is tracked as a parallel enhancement; the parity-harness test generation in archmage depends on it.
+
+## What's NOT in this crate
+
+- No tier presets. No `v1`, `v2`, `v3`, `v4` constants. Users write `enable = "avx2,fma,..."` because spelling it out is the whole point.
+- No token types. Users who want token-as-proof pass archmage tokens into their `#[cpu_tier]` functions themselves.
+- No body rewriting. `$body:block` captures verbatim; the macro only attaches attributes.
+- No autoversion. Scalar-body cloning is a separate concern; this crate does not have opinions about how you produce the per-tier bodies.
+- No parity test harness. That lives in archmage or as a sibling crate — it needs the tier enum `chain!` generates, so it's a natural follow-up.
+
+## Sizing target
+
+- `src/lib.rs` ≤ 500 lines, proc-macro + parsing + codegen.
+- No other source files initially. Every concern fits in one file; users fork by copying `lib.rs` + `Cargo.toml`.
+- Zero-dep beyond `syn`/`quote`/`proc-macro2`.
+
+## Decisions (resolved 2026-04-20)
+
+- **Feature-set resolution:** Option A — inline at the chain site. Every feature string visible at both `#[cpu_tier]` and `#[chain]`. Mismatch is a user bug with a documented failure mode; future revision may add const-based equality check.
+- **`chain` form:** attribute macro on an empty-body function (`#[chain(...)] pub fn compute(...) -> T {}`). Reads the signature from the function; attribute args carry the tier lists.
+- **Default keyword:** `default` (not `scalar`). Honest on no-SIMD architectures where there is no "scalar vs vector" split.
+- **Arch inference:** enabled by default. Inference failure (all features ambiguous) is a compile error, not a silent default. Users override with explicit `arch = "..."` in `#[cpu_tier]`.
+
+## Remaining open questions
+
+- **Name mangle for chain trampolines:** `compute__chain_v3` is the current sketch. Pick the ugliest double-underscore name the user can't accidentally collide with.
+- **Test-hook tier enum shape:** per-chain `ArtisanTier` enum generated as a public type alongside `force_max_tier`. Naming convention for variants (`V3`, `V2`, etc.) vs the user's actual fn suffixes? Probably the fn suffix uppercased — the user chose the name, respect it.

--- a/artisan-macros/HANDOFF.md
+++ b/artisan-macros/HANDOFF.md
@@ -1,0 +1,95 @@
+# artisan-macros handoff
+
+Draft state snapshot. Captured for review at a later date.
+
+## What exists
+
+A working draft of `artisan-macros` — two proc-macros (`#[cpu_tier]`, `#[chain]`) with a thread-local test-hook layer, compile-time feature-string equality check, real-SIMD-kernel test, and dedicated CI workflow. 9 tests pass on x86_64 Linux.
+
+File inventory:
+
+| File | Purpose | Reviewed? |
+|---|---|---|
+| `Cargo.toml` | Proc-macro crate with `artisan_test_hooks` feature, `syn`/`quote`/`proc-macro2` deps | draft |
+| `src/lib.rs` | Single-file implementation — parsing, arch inference, cpu_tier expansion, chain expansion, feature-string const + assertion, test-hooks codegen. ~840 LoC. | draft |
+| `DESIGN.md` | Design rationale: trampoline-chain model, tri-state cache, compile-time entry, user-owned suffixes, forbid(unsafe_code) compat, constant-CPUID axiom | draft |
+| `SPEC-CPU-TIER.md` | Normative spec for `#[cpu_tier]` — grammar, output, arch inference, validation rules | draft (pre-feature-const; update needed) |
+| `SPEC-CHAIN.md` | Normative spec for `#[chain]` — grammar, expansion shape, cache semantics, compile-time elision, feature-string duplication rules | draft (pre-feature-const; update needed) |
+| `SPEC-TEST-HOOKS.md` | Normative spec for the thread-local `force_max_tier` RAII API and its concurrency properties | draft |
+| `README.md` | User-facing overview, shows the canonical usage shape | draft |
+| `tests/smoke.rs` | 3-test smoke suite: dispatch correctness, idempotence, test-hook scope isolation. Scalar bodies in every tier. | passing on x86_64 |
+| `tests/real_kernel.rs` | 6-test real-SIMD test: sums an `&[f32]` using AVX2+FMA on x86_64 and NEON on aarch64. Unsafe intrinsics inside tier bodies (not forbid-compat; by design for this test). | passing on x86_64 |
+| `tests/expand.rs` | macrotest driver: globs `tests/expand/*.rs` and compares expansions to committed `.expanded.rs` snapshots. Gated on `target_arch = "x86_64"` because `cargo expand` strips non-host cfg branches. | passing on x86_64 |
+| `tests/expand/*.rs` + `*.expanded.rs` | 4 snapshot pairs: simple cpu_tier, cpu_tier with explicit arch, single-arch chain, multi-arch chain. Any drift in macro output fails the expand test. | committed |
+| `.github/workflows/artisan-macros.yml` | Dedicated CI: test on ubuntu/windows/windows-11-arm/macos-intel/macos-latest; cross to i686/aarch64/armv7; clippy/fmt/docs; expansion-snapshot drift check; deliberate-mismatch self-test to prove the compile-time check fires. | unverified (not yet run in CI) |
+| `PARITY_HARNESS_ISSUE_DRAFT.md` | GitHub issue text for archmage enhancement: "add cross-tier parity test harness" | draft, unposted |
+| `ARCHMAGE-THREAD-LOCAL-ISSUE.md` | GitHub issue text for archmage enhancement: "add thread-local override layer to token caches" (prerequisite to the parity harness) | draft, unposted |
+
+## Build status (local, 2026-04-20)
+
+```
+cargo check -p artisan-macros                                     ✓
+cargo clippy -p artisan-macros --all-targets -- -D warnings       ✓
+cargo clippy -p artisan-macros --all-targets --features artisan_test_hooks -- -D warnings   ✓
+cargo test -p artisan-macros                                      ✓ (10 tests pass: 3 smoke + 6 real_kernel + 1 expand snapshot)
+cargo fmt -p artisan-macros -- --check                            ✓
+RUSTDOCFLAGS=-D warnings cargo doc -p artisan-macros --no-deps    ✓
+```
+
+The feature-string compile-time check was sanity-verified by deliberately mutating `tests/smoke.rs` to declare `"avx2,fma,bmi2"` in `#[chain]` while `#[cpu_tier]` still said `"avx2,fma"`. Build failed with the expected `artisan-macros feature-string mismatch for tier \`dot_v3\` on arch \`x86_64\`` error. Reverted.
+
+Not tested / not verified:
+
+- **aarch64 cross-build** and test execution via `cross`. CI matrix includes it but hasn't been run yet.
+- **wasm32 build**. `#[chain]` rejects wasm32 explicitly. `#[cpu_tier(enable = "simd128")]` alone should work but is untested.
+- **Release builds** (`cargo check --release`). Untested locally; CI does debug only today.
+- **`#![forbid(unsafe_code)]` downstream** — no test crate asserts this yet. The claim is unchanged (macro expansions don't require user `unsafe`); verification is pending.
+- **Windows ARM64 (`windows-11-arm`)** in CI — included in the matrix but not yet run.
+
+## Decisions locked in (from this session)
+
+1. `chain` is an attribute macro (`#[chain(...)]`), not function-like.
+2. Fallback keyword is `default`, not `scalar`.
+3. `#[cpu_tier]` infers `target_arch` from feature names when unambiguous; fails loudly when all features are ambiguous. Users can override with `arch = "..."`.
+4. Feature-set resolution is Option A: inline strings at both `#[cpu_tier]` and `#[chain]` sites. No hidden registry. Mismatches are user bugs documented in `SPEC-CHAIN.md`.
+5. Test hooks use a thread-local `Option<u8>` override consulted by each trampoline, with an RAII scope guard. Per-thread isolation means no `#[serial]` or `RUST_TEST_THREADS=1` needed for parity tests.
+6. Feature flag for test hooks: `artisan_test_hooks` (underscored). Unit tests inside the declaring crate also get hooks via `cfg(test)`.
+
+## Open questions for review
+
+Enumerated at the end of each SPEC file. Most salient:
+
+- **SPEC updates pending.** `SPEC-CPU-TIER.md` and `SPEC-CHAIN.md` predate the feature-string const + compile-time assertion. Needs a Revisions section describing the emitted `__ARTISAN_CPU_TIER_FEATS_<fn>` const and the `const _: () = { assert!(str_eq(...)) }` blocks in chain output.
+- **Lower-tier compile-time elision** (SPEC-CHAIN.md) — current only elides the top tier per arch. Nice-to-have, not correctness.
+- **Generic fn / async fn support** (SPEC-CHAIN.md) — currently rejected for simplicity. Decide per concrete need.
+- **Trampoline mangling collision hash** (SPEC-CHAIN.md) — current mangle is `__artisan_{chain_fn}__{arch}__{tier_fn}__chain`. Unlikely to collide in practice.
+- **Process-wide force as an escape hatch** (SPEC-TEST-HOOKS.md) — currently not exposed. If rayon parity tests need it, decide on a feature-gated opt-in.
+- **CI matrix coverage.** `windows-11-arm`, `macos-latest` (Apple Silicon), and the cross targets haven't run yet. The workflow is committed and will fire on first push.
+
+## Next session, if resuming
+
+1. **Read `DESIGN.md`, then each SPEC-*.md in order.** They're written to be picked up cold.
+2. **Run `cargo test -p artisan-macros --manifest-path ../archmage-artisan/Cargo.toml`** to confirm the smoke + real_kernel suite still passes (9 tests).
+3. **Check CI status** once pushed. The first push of `.github/workflows/artisan-macros.yml` will trigger the workflow; verify all jobs pass (native x86_64/ARM64/macOS, cross i686/aarch64/armv7, lint, docs, deliberate-mismatch test).
+4. **Update SPEC-CPU-TIER.md and SPEC-CHAIN.md** to reflect the feature-string const + compile-time assertion. Both specs currently describe the pre-check state. The impl is correct; the specs are stale.
+5. **Add a downstream `#![forbid(unsafe_code)]` test crate** at `tests/forbid_unsafe/` to prove the compat claim holds (compile, not just docs).
+6. **Bench the trampoline overhead.** Expected ~1-3 ns per dispatch in the cached-hit case; the test-hooks `cfg(...)` block in each trampoline should be a zero-cost branch in release (the cfg strips it entirely).
+7. **Promote to `publish = true` + v0.1.0** once the specs align with the impl and at least one downstream consumer exists (archmage could adopt it internally as a migration path).
+
+## What NOT to do next session
+
+- **Don't publish or push to crates.io.** This is a draft; `Cargo.toml` has `publish = false`.
+- **Don't post either GitHub issue draft.** The user has them in hand (`PARITY_HARNESS_ISSUE_DRAFT.md` and `ARCHMAGE-THREAD-LOCAL-ISSUE.md`); they decide when.
+- **Don't consolidate `src/lib.rs` into modules.** The "single file" aspiration is core to the artisan ethos — if lib.rs grows past ~1000 LoC, consider splitting, but not before.
+- **Don't add tier presets or a registry.** User-owned feature strings are a feature, not an oversight.
+
+## Where this lives
+
+- jj workspace: `/home/lilith/work/archmage-artisan/` (workspace added to the archmage repo; see `jj -R ... workspace list`)
+- Primary checkout: `/home/lilith/work/archmage/` (unchanged; hasn't seen this work)
+- Bookmark: **`feat/artisan-macros-draft`** — this explicitly does NOT merge to `main`. Pushes go to the bookmark, not the main branch. Promotion to `main` requires explicit review and decision.
+- Commit hash at handoff: recorded in the final `jj log` output of the session transcript — check `jj log -r feat/artisan-macros-draft` or `git log`.
+
+## Workongoing marker
+
+`.workongoing` exists in both the primary checkout and the `../archmage-artisan` workspace. Before resuming, refresh the marker at whichever checkout you're operating in. Delete it when done.

--- a/artisan-macros/PARITY_HARNESS_ISSUE_DRAFT.md
+++ b/artisan-macros/PARITY_HARNESS_ISSUE_DRAFT.md
@@ -1,0 +1,78 @@
+## Problem
+
+When a user splits a hot kernel into `_scalar`, `_v3`, `_v4`, `_neon` variants (via `#[autoversion]`, `incant!`, or `#[rite(v3, v4, neon)]`), it is very easy to ship a kernel where one tier silently produces different output from another: an off-by-one in a lane, a wrong rounding mode, a transposed shuffle, a NaN-propagation difference, a missed signed-zero case. Archmage has seen many of these bugs while polyfilling cross-arch behaviors — the [Known Cross-Architecture Behavioral Differences table in `CLAUDE.md`](../blob/main/CLAUDE.md) is an ongoing catalogue.
+
+Writing cross-tier parity tests by hand is tedious, error-prone, and gets skipped. Every downstream crate (zenjpeg, zenresize, zenblend, zenpixels-convert, …) reinvents this scaffolding ad-hoc, if at all.
+
+## Proposal
+
+Auto-generate a cross-tier parity test harness from `#[autoversion]` / `incant!` / `#[rite]` multi-tier declarations. These macros already know the tier list and the function signature — they have everything needed to emit a `#[cfg(test)]` parity test.
+
+For each declaration, generate a test that:
+
+1. Iterates over user-supplied inputs.
+2. Computes the reference output using the `_scalar` variant.
+3. For each tier the runtime CPU actually supports, forces the dispatcher to select that tier and asserts the output matches the reference within an opt-in tolerance.
+4. Skips tiers the CPU does not support (calling them would SIGILL). Upgrade-path testing is handled by the CI matrix (see below).
+
+## Soundness of `force_max_tier`
+
+The test hook is gated behind a `test-hooks` Cargo feature, not compiled into release builds. Its only capability is to downgrade the dispatcher's tier selection — it can force the runtime to pick tier `T` or lower, but never to fabricate a tier the CPU lacks. Disabling a tier the CPU supports cannot cause UB; only fabricating a tier the CPU lacks can. Sound by construction.
+
+**Implementation: per-thread override, not atomic cache poke.** The hook is a `thread_local!<Cell<Option<Tier>>>` consulted by each trampoline before its `AtomicU8` cache. Setting the override returns an RAII scope guard that restores the previous value on drop. Properties:
+
+- **Per-thread isolation = per-test isolation.** Cargo runs one test per thread; forcing on thread A cannot affect thread B. No `#[serial]` required, no `RUST_TEST_THREADS=1`, no race between parallel parity tests.
+- **Zero cost in release.** The `#[cfg(feature = "test-hooks")]` block compiles away entirely.
+- **RAII restore.** Panic during a test still unwinds the scope and restores state.
+- **Atomic cache stays correct.** The thread-local never writes to the cache. Production detection is unaffected; test hooks only overlay.
+
+**Rayon / worker-pool caveat.** `thread_local!` values do not propagate to spawned threads. Tests that dispatch from a rayon worker pool see the real-CPU behavior in the worker, not the forced tier. Doc-note mitigation: call `force_max_tier` inside the worker closure, or use `serial_test::serial` for tests that genuinely need process-wide forcing.
+
+**Prerequisite.** Archmage's existing `dangerously_disable_token_process_wide()` writes to the process-wide atomic cache and has the same race-condition problem under parallel tests. Implementing this harness requires first adding a thread-local override layer to archmage's token caches (generated alongside the `AtomicU8` per token). That refactor is independent of the harness itself but must land first; it should be a separate tracking issue.
+
+## API sketch
+
+`#[autoversion]` gains an `inputs` argument:
+
+```rust
+#[autoversion(v3, v4, neon, parity_inputs = parity_cases())]
+fn dot(_token: SimdToken, a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+fn parity_cases() -> impl IntoIterator<Item = (Vec<f32>, Vec<f32>)> { /* ... */ }
+```
+
+Expands (behind `#[cfg(test)]`) to a generated test that runs each case through every CPU-supported tier and compares to `dot_scalar`.
+
+For `#[rite(v3, v4, neon)]` and `incant!`, a sibling attribute:
+
+```rust
+#[parity_test(inputs = cases(), tolerance = ulp(4))]
+#[rite(v3, v4, neon, import_intrinsics)]
+fn blend(a: f32x4, b: f32x4, t: f32x4) -> f32x4 { /* ... */ }
+```
+
+`tolerance` defaults to exact for integers and `ulp(0)` for floats; users opt into `ulp(N)` or `abs(eps)` for kernels where FMA-vs-separate-mul-add divergence is expected and documented.
+
+## SDE / qemu matrix
+
+Forcing a higher CPU than the host has cannot be done in-process. The recommended pattern is a CI matrix job per tier, running under Intel SDE (`sde -hsw --`, `sde -skx --`, `sde -icx --`) or `qemu-user` with `--cross-cpu`. On each job every tier up to the emulated level is "supported" and the harness exercises it. A reference workflow snippet ships in `docs/site/content/archmage/testing/parity-matrix.md`.
+
+## Relationship to existing tests
+
+Complementary, not overlapping:
+
+- `tests/feature_consistency.rs`, `tests/*_intrinsics.rs` — test the token/intrinsic plumbing (archmage's responsibility).
+- Parity harness — tests *user* kernels for bit-exactness across tiers.
+
+## Open questions
+
+- **Input ergonomics** — attribute arg (`parity_inputs = expr`), companion attribute on a user fn, or a standalone `parity_test!` macro? Attribute arg is least invasive; companion attribute composes best with `proptest`.
+- **`proptest` integration** — auto-derive strategies from signature, or require the user to pass a `Strategy`? Start with explicit, consider derive later.
+- **Tolerance defaults** — exact for ints, `ulp(0)` for floats, or `ulp(2)` to accommodate FMA drift without surprising integer users? Leaning exact-by-default.
+- **Where does the SDE recipe live** — archmage docs, a `cargo xtask parity-ci` generator, or a workspace template?
+
+## Prior art / non-goals
+
+`multiversion`, `pulp`, and hand-rolled `target_feature` dispatch all lack any parity harness. `proptest` is a plausible input generator but is not itself a tier-aware test. Non-goal: testing tiers the host CPU cannot run without emulation — that is the CI matrix's job, not the harness's.

--- a/artisan-macros/README.md
+++ b/artisan-macros/README.md
@@ -1,0 +1,56 @@
+# artisan-macros
+
+Auditable, convention-forward proc-macros for sound SIMD tier dispatch.
+
+Two macros, one file, user-owned feature strings. No tier registry, no codegen step, no body rewriting. Read the crate top to bottom in a sitting, fork it if you want to.
+
+Status: **design-phase skeleton.** See [DESIGN.md](./DESIGN.md) for the full sketch.
+
+## The shape
+
+```rust
+use artisan_macros::{cpu_tier, chain};
+
+#[cpu_tier(enable = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe")]
+fn compute_v3(data: &[f32]) -> f32 { /* hand-written AVX2+FMA */ }
+
+#[cpu_tier(enable = "sse4.2,popcnt")]
+fn compute_v2(data: &[f32]) -> f32 { /* hand-written SSE4.2 */ }
+
+#[cpu_tier(enable = "neon")]
+fn compute_neon(data: &[f32]) -> f32 { /* hand-written NEON */ }
+
+fn compute_scalar(data: &[f32]) -> f32 { data.iter().sum() }
+
+#[chain(
+    x86_64 = [
+        compute_v3 = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe",
+        compute_v2 = "sse4.2,popcnt",
+    ],
+    aarch64 = [
+        compute_neon = "neon",
+    ],
+    default = compute_scalar,
+)]
+pub fn compute(data: &[f32]) -> f32 {}
+```
+
+Each arch chain is a trampoline sequence: `compute_v3`'s cache miss falls through to `compute_v2`'s cache miss falls through to `compute_scalar`. One `AtomicU8` per tier, tri-state (empty/false/true). The entry function is a compile-time arch switch — no per-call-site dispatch tree.
+
+## What it is
+
+- ~500 LoC proc-macro crate, single `lib.rs`
+- Emits `#[target_feature]` + `#[cfg(target_arch)]` + `#[inline]` via `#[cpu_tier]`
+- Emits a trampoline chain + atomic caches + entry dispatcher via `chain!`
+- `#![forbid(unsafe_code)]`-compatible downstream (macro-emitted `unsafe` is exempt)
+- Constant-CPUID axiom is the only soundness assumption beyond what Rust already requires
+
+## What it is not
+
+- Not a replacement for archmage's token system, `#[magetypes]`, `#[autoversion]`, or `incant!`
+- Not a tier registry — users own their feature strings and suffixes
+- Not a benchmarking or testing framework — test hooks are provided behind a feature flag, parity harness lives elsewhere
+
+## License
+
+MIT OR Apache-2.0

--- a/artisan-macros/SPEC-CHAIN.md
+++ b/artisan-macros/SPEC-CHAIN.md
@@ -1,0 +1,205 @@
+# SPEC: `#[chain]`
+
+Normative specification for the `#[chain]` attribute macro in artisan-macros.
+
+Status: **draft** — implementation exists in `src/lib.rs`, awaiting review.
+
+## Synopsis
+
+```rust
+#[chain(
+    <arch> = [ <tier_fn> = "<features>", ... ],
+    ...,
+    default = <fallback_fn>,
+)]
+<vis> fn <name>(<params>) <return> {}
+```
+
+Applied to a function with an empty body. The macro reads the function signature, discards the empty body, and emits:
+
+1. An entry function with the same signature, whose body is a compile-time arch switch with per-arch compile-time feature elision.
+2. One trampoline per tier, each with its own `AtomicU8` cache and a thread-local override check.
+3. A test-hook surface (per-chain enum, `force_max_tier` function, RAII scope guard, thread-local cell) behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`.
+
+## Input grammar
+
+Formal grammar in EBNF:
+
+```
+chain_args   := entry ( "," entry )* ","?
+entry        := arch_entry | default_entry
+arch_entry   := arch_ident "=" "[" tier_entry ( "," tier_entry )* ","? "]"
+default_entry := "default" "=" ident
+tier_entry   := ident "=" lit_str
+arch_ident   := "x86_64" | "x86" | "aarch64" | "arm" | "wasm32"
+```
+
+- Tier order within an arch list is **highest-to-lowest**: the first tier is tried first; cache-miss falls through to the next.
+- Exactly one `default` entry is required.
+- Arch idents must appear at most once per chain.
+- Tier function idents must be unique within an arch (they may repeat across arches, though this is unusual).
+- The annotated function body must be an empty block `{}`. A non-empty body is a compile error.
+- The annotated function must be a safe, non-async, non-generic `fn`. Methods with `self` receivers are rejected.
+
+## Expansion
+
+For a chain declared as
+
+```rust
+#[chain(
+    x86_64 = [ F_a = "feats_a", F_b = "feats_b" ],
+    aarch64 = [ F_n = "feats_n" ],
+    default = F_d,
+)]
+pub fn NAME(p1: T1, p2: T2) -> R {}
+```
+
+the macro emits approximately:
+
+```rust
+// Entry function — compile-time arch switch.
+pub fn NAME(p1: T1, p2: T2) -> R {
+    #[cfg(target_arch = "x86_64")]
+    {
+        #[cfg(all(target_feature = "feats_a_1", target_feature = "feats_a_2", ...))]
+        { unsafe { F_a(p1, p2) } }
+        #[cfg(not(all(target_feature = "feats_a_1", ...)))]
+        { __artisan_NAME__x86_64__F_a__chain(p1, p2) }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        #[cfg(target_feature = "feats_n")]
+        { unsafe { F_n(p1, p2) } }
+        #[cfg(not(target_feature = "feats_n"))]
+        { __artisan_NAME__aarch64__F_n__chain(p1, p2) }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    { F_d(p1, p2) }
+}
+
+// Per-tier trampolines.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_NAME__x86_64__F_a__chain(p1: T1, p2: T2) -> R {
+    // Thread-local override (test-hooks only).
+    #[cfg(any(test, feature = "artisan_test_hooks"))]
+    { /* see SPEC-TEST-HOOKS.md for the exact shape */ }
+
+    use ::core::sync::atomic::{AtomicU8, Ordering};
+    static CACHE: AtomicU8 = AtomicU8::new(0);
+    match CACHE.load(Ordering::Relaxed) {
+        2u8 => unsafe { F_a(p1, p2) },
+        1u8 => __artisan_NAME__x86_64__F_b__chain(p1, p2),
+        _ => {
+            let ok = ::std::is_x86_feature_detected!("feats_a_1")
+                  && ::std::is_x86_feature_detected!("feats_a_2")
+                  && /* ... */;
+            CACHE.store(if ok { 2u8 } else { 1u8 }, Ordering::Relaxed);
+            if ok { unsafe { F_a(p1, p2) } } else { __artisan_NAME__x86_64__F_b__chain(p1, p2) }
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_NAME__x86_64__F_b__chain(p1: T1, p2: T2) -> R {
+    // ...same shape; `F_b` on cache-hit, `F_d(...)` on miss (default fallback)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_NAME__aarch64__F_n__chain(p1: T1, p2: T2) -> R {
+    // ...same shape; `F_n` on cache-hit, `F_d(...)` on miss
+}
+
+// Test-hook declarations (see SPEC-TEST-HOOKS.md).
+```
+
+### Mangling convention
+
+- Trampoline name: `__artisan_{chain_fn}__{arch}__{tier_fn}__chain`.
+- Thread-local module: `__artisan_{chain_fn}_hooks`.
+- Tier enum: `{CapitalizedChainFn}Tier`.
+- Scope guard: `{CapitalizedChainFn}Scope`.
+- Force function: `{chain_fn}_force_max_tier`.
+
+All emitted with `#[allow(non_snake_case)]` where needed.
+
+### Cache semantics
+
+- One `AtomicU8` cache per tier, named `CACHE` and scoped to the trampoline function (private to the expansion; two trampolines never share a cache even if they carry the same feature set).
+- Values: `0` = empty / unchecked; `1` = false / CPU lacks features; `2` = true / CPU has features.
+- Accessed with `Ordering::Relaxed`. The cached value is idempotent (CPUID is a pure function on tier-1 targets), so racing threads writing the same result is benign.
+- Initialised to `0`. First reader performs the check, stores the result, and proceeds.
+
+### Per-arch detection macro
+
+| Arch | Runtime detection macro |
+|---|---|
+| `x86_64`, `x86` | `::std::is_x86_feature_detected!` |
+| `aarch64` | `::std::is_aarch64_feature_detected!` |
+| `arm` | `::std::is_arm_feature_detected!` |
+| `wasm32` | **not supported in runtime dispatch** — see below |
+
+### wasm32 limitation
+
+wasm32 has no runtime feature detection. A `#[chain]` entry with `wasm32 = [ ... ]` fails compilation with a clear error. On wasm32, put SIMD tier functions on the compile-time path only: annotate with `#[cpu_tier(enable = "simd128")]` and check `#[cfg(target_feature = "simd128")]` in the default path to pick between the SIMD tier and a scalar fallback manually. A future revision may add `chain` support for wasm32 via compile-time-only dispatch.
+
+## Feature-string duplication
+
+The feature string appears in **two places**:
+
+1. `#[cpu_tier(enable = "...")]` on the tier function definition. Drives `#[target_feature]`.
+2. `#[chain(<arch> = [<tier> = "...", ...])]` at the chain site. Drives `is_*_feature_detected!` and `#[cfg(target_feature = "...")]`.
+
+**The two strings must match exactly.** The current draft does not enforce equality at macro expansion time (it cannot — a proc-macro cannot read attributes from a sibling function). Mismatches are user bugs. Failure modes:
+
+- `cpu_tier` features ⊂ `chain` features: the runtime CPUID check verifies more than `#[target_feature]` enabled. LLVM never emits instructions for features the function wasn't compiled with, so this is safe but wastes detection bandwidth.
+- `cpu_tier` features ⊃ `chain` features: the runtime check verifies less than the function requires. On a CPU that passes the check but lacks the extra features, LLVM-emitted instructions for the extra features trap with SIGILL. **This is unsound and is a user bug.**
+
+A future revision may add a compile-time equality check by emitting a `const FEATURES_chain_NAME_TIER: &str = "..."` from `#[cpu_tier]` and a `const _: () = assert!(FEATURES_chain_NAME_TIER == "...")` from `#[chain]`. Out of scope for the current draft.
+
+## Compile-time elision
+
+The entry function's body fast-paths via `#[cfg(all(target_feature = "..."))]`. When the build target fully covers a tier's features (e.g. `-Ctarget-cpu=haswell` or `-Ctarget-feature=+avx2,+fma,...`), the top-tier elision block fires at compile time and the entry function becomes a single direct call. The `AtomicU8` cache, CPUID check, and trampoline chain are dead code eliminated.
+
+**Current draft elides only the top tier per arch.** A fuller implementation elides every tier (with mutually exclusive `cfg(not(all(...)))` clauses to maintain single-match semantics). The top-tier elision covers the common case (build for native + top tier exactly matches); lower-tier elision is an optimisation for mid-range build targets. Not required for correctness.
+
+## Validation rules
+
+| Condition | Error |
+|---|---|
+| No `default` entry | `missing required \`default = <fn_name>\` entry` |
+| Multiple `default` entries | `multiple \`default = ...\` entries` |
+| Arch listed twice | `arch \`<arch>\` listed more than once in #[chain]` |
+| Tier function repeated in one arch | `tier function \`<fn>\` listed more than once under arch \`<arch>\`` |
+| Empty tier list for an arch | `arch \`<arch>\` has an empty tier list; remove it or add tiers` |
+| Empty feature list for a tier | `empty feature list for tier \`<fn>\`` |
+| `unsafe fn` | `#[chain] expects a safe \`fn\`, not \`unsafe fn\`` |
+| `async fn` | `#[chain] does not support \`async fn\` in the current draft` |
+| Generic fn | `#[chain] does not support generic functions in the current draft` |
+| `self` receiver | `#[chain] cannot be applied to methods with \`self\` receivers; apply to a free function` |
+| Destructuring param pattern | `#[chain] expects simple \`name: Type\` parameters (no destructuring)` |
+| `ref` / `mut` binding / subpattern | `#[chain] expects simple \`name: Type\` parameters (no \`ref\`, no \`mut\` binding, no subpatterns)` |
+| wasm32 in chain | `wasm32 has no runtime feature detection; SIMD tiers on wasm must rely on compile-time features only. ...` |
+| Unsupported arch | `unsupported arch \`<arch>\` in #[chain]: expected x86_64, x86, aarch64, or arm` |
+
+## Soundness claims
+
+1. **Every `unsafe` block in the expansion is proc-macro-generated**, inside spans traceable to artisan-macros. Downstream `#![forbid(unsafe_code)]` compiles generated code without modification.
+2. **Every `unsafe` block is preceded by a runtime CPUID check or a compile-time `cfg(target_feature)` check** verifying the features required by the called function's `#[target_feature]`.
+3. **Cache-hit `2u8` implies the check previously succeeded** — no `unsafe` call is reached without feature verification.
+4. **Cache-miss on first call performs the check before dispatch** — the first dispatch on any cache is never unsafe-without-verification.
+5. **Default fallback is always reachable** — every chain bottoms out at the user's `default` fn, which has no feature requirements.
+6. **Constant-CPUID axiom** (from DESIGN.md): tier-1 Rust targets do not change CPU features during process lifetime. The cache is a memoisation of a pure function.
+
+## Open questions (for review)
+
+- **Lower-tier compile-time elision.** Currently only top tier per arch elides; lower tiers always take the runtime path. Add full elision with mutually exclusive `cfg(not(all(...)))` clauses?
+- **Feature-string equality check.** Implement the `const FEATURES_*` + `assert!` mechanism to catch cpu_tier ↔ chain mismatches at compile time?
+- **Generic function support.** The current draft rejects generics for simplicity. Add support by emitting generic trampolines and routing `arg_idents` through? Trampoline monomorphisation cost may matter.
+- **`async fn` support.** Probably straightforward — trampoline returns the future. Design question: should the trampoline be `async`, or should it return an `impl Future` that does the dispatch on first poll?
+- **Trampoline mangling collision.** Two `#[chain]` declarations with the same `chain_fn` name in the same module (e.g. via `use ... as ...`) would collide. The double-underscore prefix plus the arch and tier_fn segments make this unlikely in practice; is it worth hashing?

--- a/artisan-macros/SPEC-CPU-TIER.md
+++ b/artisan-macros/SPEC-CPU-TIER.md
@@ -1,0 +1,132 @@
+# SPEC: `#[cpu_tier]`
+
+Normative specification for the `#[cpu_tier]` attribute macro in artisan-macros.
+
+Status: **draft** — implementation exists in `src/lib.rs`, awaiting review.
+
+## Synopsis
+
+```rust
+#[cpu_tier(enable = "<features>" [, arch = "<target_arch>"])]
+fn <name>(<params>) <return> { <body> }
+```
+
+Attaches `#[target_feature(enable = "<features>")]`, `#[cfg(target_arch = "<target_arch>")]`, and `#[inline]` to the annotated function. Does not otherwise modify the function.
+
+## Input grammar
+
+Attribute arguments are a comma-separated list of `name = "string"` pairs. Required and optional args:
+
+| Arg | Required | Type | Description |
+|---|---|---|---|
+| `enable` | yes | string literal | Comma-separated feature names, same grammar as `#[target_feature(enable = "...")]` |
+| `arch` | no | string literal | Explicit `target_arch` override. One of `"x86_64"`, `"x86"`, `"aarch64"`, `"arm"`, `"wasm32"` |
+
+Both args may appear in either order. Neither may appear more than once.
+
+The attribute must be applied to an `ItemFn` (a top-level `fn` or one in an inherent impl). The function must be a safe `fn`, not `unsafe fn`.
+
+## Output grammar
+
+Given
+
+```rust
+#[cpu_tier(enable = "<F>", arch = "<A>")]
+<vis> fn <name><generics>(<params>) <return> <where>? { <body> }
+```
+
+the macro emits
+
+```rust
+#[cfg(target_arch = "<A>")]
+#[target_feature(enable = "<F>")]
+#[inline]
+<vis> fn <name><generics>(<params>) <return> <where>? { <body> }
+```
+
+Existing attributes on the input function are preserved; the three macro-added attributes are prepended.
+
+## Arch inference
+
+When `arch` is omitted, the macro scans `enable` left-to-right for a feature listed in the unambiguous-features table (`src/lib.rs` § `UNAMBIGUOUS_FEATURES`) and selects that feature's `target_arch`. The first match wins.
+
+The table covers:
+
+- **x86_64**: every documented `stdarch` feature that is exclusive to x86 (SSE1–4.2, POPCNT, AVX, AVX2, FMA, BMI1/2, LZCNT, F16C, MOVBE, all AVX-512 variants, VPCLMULQDQ, VAES, GFNI, PCLMULQDQ, CMPXCHG16B).
+- **aarch64**: NEON, RDM, DotProd, FHM, FCMA, I8MM, BF16, SVE, SVE2, PMULL.
+- **wasm32**: SIMD128, relaxed-simd.
+
+**Ambiguous features**: `aes`, `sha2`, `sha3`, `crc`, `fp16`. These are present on more than one arch under the same stdarch feature string. They do **not** drive inference. If every feature in `enable` is ambiguous, inference fails with a compile error directing the user to add explicit `arch = "..."`.
+
+Arch inference never silently defaults to a wrong arch. Either a known-arch feature is present (inference succeeds) or the user explicitly says which arch (explicit wins) or compilation fails (safe default).
+
+## Validation rules
+
+Errors emitted at macro expansion time (all as `compile_error!`):
+
+| Condition | Error |
+|---|---|
+| No `enable` arg | `missing required \`enable = "..."\` argument` |
+| `enable` specified twice | `\`enable\` specified twice` |
+| `arch` specified twice | `\`arch\` specified twice` |
+| Unknown arg name | `unknown argument \`<name>\`; expected \`enable\` or \`arch\`` |
+| Non-literal arg value | `expected string literal (e.g. "avx2,fma")` |
+| Function is `unsafe fn` | `#[cpu_tier] expects a safe \`fn\`, not \`unsafe fn\`. Rust 2024 edition allows \`#[target_feature]\` on safe fns; \`unsafe fn\` would break \`#![forbid(unsafe_code)]\` for downstream crates.` |
+| Inference fails and no explicit `arch` | `cannot infer target_arch from features \`<features>\`: all listed features are ambiguous or unknown to artisan-macros. Add explicit \`arch = "x86_64" | "aarch64" | "wasm32"\`.` |
+| Explicit `arch` outside supported set | `arch \`<arch>\` is not one of: x86_64, x86, aarch64, arm, wasm32. (artisan-macros supports these five target_arch values.)` |
+
+The macro does **not** validate feature names against a known table. Misspelled features (e.g., `avx22`) reach `#[target_feature(enable = "...")]`, where rustc raises its own error.
+
+## Invariants
+
+1. **Generated function is always `fn`, never `unsafe fn`.** Rust 2024 edition permits safe fns with `#[target_feature]`; emitting `unsafe fn` would break `#![forbid(unsafe_code)]` in downstream crates.
+2. **`#![forbid(unsafe_code)]` downstream.** Generated code contains no `unsafe` keyword. Downstream users with the forbid lint compile the output without modification.
+3. **Feature string is verbatim.** `enable = "avx2,fma"` becomes `#[target_feature(enable = "avx2,fma")]`. No whitespace trimming, sorting, or deduplication.
+4. **Arch gating is absolute.** The `#[cfg(target_arch = "...")]` is emitted on the function. Compilation for any other arch excludes the function entirely; references must be `#[cfg]`-gated or routed through `#[chain]` (which cfg-gates its trampolines).
+5. **`#[inline]` is always added.** Non-inlining of tier functions breaks `#[chain]`'s compile-time elision; every tier function is a candidate for inlining into callers with matching target features.
+
+## Examples
+
+### Canonical x86_64 v3 tier
+
+```rust
+#[cpu_tier(enable = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe")]
+fn dot_v3(a: &[f32; 8], b: &[f32; 8]) -> f32 {
+    // hand-written AVX2+FMA intrinsics
+}
+```
+
+Arch inferred as `x86_64` via `avx2`.
+
+### Ambiguous features → explicit arch required
+
+```rust
+// This would fail inference: aes, sha2 are both on x86 and ARM:
+// #[cpu_tier(enable = "aes,sha2")]
+// fn crypto_step(...) { ... }
+
+// Correct: say which arch.
+#[cpu_tier(enable = "aes,sha2", arch = "aarch64")]
+fn crypto_step(...) { ... }
+```
+
+### NEON tier
+
+```rust
+#[cpu_tier(enable = "neon")]
+fn dot_neon(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    // hand-written NEON
+}
+```
+
+## Non-goals
+
+- **Tier name inference.** `#[cpu_tier]` knows nothing about `_v3` / `_v4` / `_neon` suffixes. Those are a convention for the `#[chain]` reader, not this macro.
+- **Feature-set validation against stdarch.** The macro does not maintain a list of known valid feature strings; rustc does that in its `#[target_feature]` implementation.
+- **Token types.** No `X64V3Token`, `NeonToken`, etc. Users who want archmage-style tokens pass them as function parameters themselves.
+
+## Open questions (for review)
+
+- Should inference accept `fp16` as ambiguous-strict (current), or aarch64-biased (since x86 uses `f16c`, not `fp16`)? Current: ambiguous-strict. Trades a user-friendly inference against consistency.
+- Should the error message for inference failure list the ambiguous features? Current: no, generic message. Could help debugging but adds implementation complexity.
+- Support for `enable_if = "..."` or other future `target_feature` args? Not planned; add only on concrete need.

--- a/artisan-macros/SPEC-TEST-HOOKS.md
+++ b/artisan-macros/SPEC-TEST-HOOKS.md
@@ -1,0 +1,126 @@
+# SPEC: test hooks
+
+Normative specification for the thread-local override / `force_max_tier` API emitted by `#[chain]` in artisan-macros.
+
+Status: **draft** — implementation exists in `src/lib.rs`, awaiting review.
+
+## Synopsis
+
+Behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`, every `#[chain]` expansion emits a per-chain API that lets tests downgrade the dispatcher's tier selection on the current thread only, without touching the process-wide atomic cache.
+
+```rust
+#[chain( /* ... */ )]
+pub fn compute(data: &[f32]) -> f32 {}
+```
+
+Emits (test-hook surface only, full expansion in SPEC-CHAIN.md):
+
+```rust
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+pub enum ComputeTier { /* one variant per tier, in declared order */, Default }
+
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+#[must_use = "dropping the scope immediately restores the previous override"]
+pub struct ComputeScope { /* opaque */ }
+
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+pub fn compute_force_max_tier(tier: ComputeTier) -> ComputeScope;
+```
+
+## Semantics
+
+Calling `compute_force_max_tier(t)`:
+
+1. Reads the current thread-local override (`Option<u8>` tier index) into a local.
+2. Writes the chosen tier's index (or `Default` → last+1) into the thread-local.
+3. Returns a `ComputeScope` containing the previous value.
+
+On `ComputeScope::drop`:
+
+1. Writes the stored previous value back into the thread-local.
+
+Each trampoline in the chain reads the thread-local before its atomic cache. If the override is `Some(max_idx)` and the trampoline's own tier index is strictly less than `max_idx` (i.e., the trampoline is a HIGHER tier than allowed), the trampoline returns the next-tier dispatch directly, skipping both the atomic cache check and the feature detection.
+
+**Tier indexing convention:** the first tier declared in `#[chain]` is index `0` (highest). Subsequent tiers increase by `1`. `Default` is `<tier_count>`. Forcing to tier index `k` means "do not run any tier with index `< k`."
+
+### Example
+
+```rust
+#[chain(
+    x86_64 = [ fast_v4 = "...", fast_v3 = "..." ],
+    aarch64 = [ fast_neon = "..." ],
+    default = fast_scalar,
+)]
+pub fn fast(data: &[f32]) -> f32 {}
+
+// Indices: fast_v4 = 0, fast_v3 = 1, fast_neon = 2, Default = 3
+// (Neon is on aarch64 so index 2 only matters on aarch64; on x86_64 its
+//  trampoline is #[cfg]-gated out and never compiles.)
+```
+
+On x86_64 with AVX-512 ambient:
+
+- `force_max_tier(FastTier::V4)` (idx 0): v4 runs (0 < 0 false, proceed).
+- `force_max_tier(FastTier::V3)` (idx 1): v4 skips (0 < 1 → skip), v3 runs.
+- `force_max_tier(FastTier::Default)` (idx 3): v4 skips, v3 skips, scalar runs.
+
+## Invariants
+
+1. **Per-thread isolation.** `force_max_tier` on thread A has no effect on thread B. Cargo's test runner assigns one thread per test by default; parallel parity tests do not interfere.
+2. **Zero cost in release.** Without `cfg(test)` or `cfg(feature = "artisan_test_hooks")`, every trampoline is compiled without the override block, without the thread-local read, and without the override branch. The type surface (enum, scope, force fn) is not emitted at all.
+3. **RAII restoration.** `Drop` restores the previous override. Panic during a test unwinds the scope and restores state. Tests cannot leak forced state across test functions.
+4. **Nested overrides compose.** `force_max_tier(V3)` inside a test that already has `force_max_tier(V4)` set stores `V4` as `prev`, overrides to `V3`. On drop, restores `V4`. On outer drop, restores `None`.
+5. **Atomic cache is untouched.** The thread-local never writes to the atomic cache. Production detection state remains correct across test runs.
+6. **Downgrade-only.** The API exposes `Option<u8>` with tier indices in declared order plus `Default`. It cannot set the override to a variant that does not exist. It cannot fabricate availability of a tier the CPU lacks — all it can do is restrict selection to lower-or-equal tiers.
+
+## Soundness
+
+The test-hook API can only disable tiers. The `force_max_tier` function takes a value of the generated `Tier` enum, whose variants are exactly the tiers declared in `#[chain]` plus `Default`. It cannot be passed a tier the declaration does not include.
+
+Disabling a tier:
+
+- Does NOT cause a `#[target_feature]` function to be called on a CPU that lacks those features. The trampoline skips to the next-tier trampoline, whose own cache check verifies the next tier's features before any `unsafe` call.
+- Cannot cause UB by itself — the thread-local controls a choice between tier trampolines, all of which perform their own verification.
+- Cannot corrupt other threads' dispatch decisions because the thread-local is per-thread.
+
+Fabricating a tier (writing `max_idx` higher than any declared tier) is not exposed by the API. The only way to get `Default` is via the `Default` variant, which is `<tier_count>` — equal to or higher than every tier index, meaning "skip everything."
+
+## Rayon / worker-pool caveat
+
+`std::thread_local!` values do not propagate to spawned threads. A test that calls `force_max_tier` on the main thread and then dispatches from a rayon `par_iter` worker sees the main thread's override only in code running directly on the main thread. Worker threads have their own thread-local (initialised to `None`) and dispatch via the real-CPU atomic cache.
+
+Mitigations:
+
+- Propagate manually: inside the rayon worker closure, call `force_max_tier` again. The closure's `ComputeScope` restores the override on worker drop.
+- Use `serial_test::serial` and a process-wide forcing mechanism (not exposed by default — process-wide forcing is deliberately avoided to keep parallel tests clean).
+- Run rayon-using parity tests on `cargo test -- --test-threads=1` or as `#[serial]`-annotated tests.
+
+This is a genuine limitation. In practice, parity harness tests are single-threaded (they call a function with an input and compare outputs) and do not hit this case. The caveat is worth a documentation note, not a design rework.
+
+## Feature gating
+
+The thread-local, enum, scope, and force function are emitted behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`.
+
+- Unit tests inside the crate declaring `#[chain]` get the hooks automatically via `cfg(test)`.
+- Downstream integration-test crates (which compile the library as a dependency, not as a test target) need to enable the `artisan_test_hooks` feature on the crate that owns the `#[chain]` declaration. The convention is:
+
+```toml
+# In the crate that owns #[chain]:
+[features]
+artisan_test_hooks = ["artisan-macros/artisan_test_hooks"]
+# or, if the crate does not gate its own code on the feature:
+artisan_test_hooks = []
+```
+
+The trampolines themselves check `cfg(feature = "artisan_test_hooks")` (propagated through the macro expansion, not through `artisan-macros`'s own Cargo features). The declaring crate must have a feature of this name; tests enable it via `cargo test --features artisan_test_hooks`.
+
+## Fit with the archmage parity-harness proposal
+
+The parity harness proposed for archmage (`PARITY_HARNESS_ISSUE_DRAFT.md`) needs per-thread downgrade scoping as a prerequisite. Archmage's current `dangerously_disable_token_process_wide()` writes to the process-wide atomic cache, racing under parallel tests. The artisan-macros design is the correct shape for archmage too. See `ARCHMAGE-THREAD-LOCAL-ISSUE.md` for the proposed archmage refactor.
+
+## Open questions (for review)
+
+- **`Option<Tier>` in the cell vs `Option<u8>` with index discipline.** Current: `Option<u8>`. Simpler, but couples trampoline code to the declaration order. `Option<Tier>` with the enum stored directly is more self-documenting but adds coupling between the trampoline mod and the enum module.
+- **Expose an "unforce" API.** Drop of the scope restores; if a test wants to explicitly unforce without dropping, should we expose `release_force_max_tier()`? Probably no — breaks RAII guarantees.
+- **Process-wide forcing as a deliberate escape hatch.** Not exposed by default. If a user genuinely needs it (for `#[serial]` rayon cases), should we add `force_max_tier_process_wide()` under a separate feature flag (`artisan_test_hooks_process_wide`)? Probably no — it's a footgun.
+- **Test-hook feature name.** Current: `artisan_test_hooks` (underscored). Alternative: `test-hooks` (hyphenated, Cargo convention). Chose underscored to avoid collision with user-chosen feature names; revisit on feedback.

--- a/artisan-macros/src/lib.rs
+++ b/artisan-macros/src/lib.rs
@@ -1,0 +1,840 @@
+//! # artisan-macros
+//!
+//! Auditable, convention-forward proc-macros for sound SIMD tier dispatch.
+//!
+//! See the companion markdown files for the full design and specs:
+//!
+//! - `DESIGN.md` — design rationale, trampoline-chain model
+//! - `SPEC-CPU-TIER.md` — normative spec for `#[cpu_tier]`
+//! - `SPEC-CHAIN.md` — normative spec for `#[chain]`
+//! - `SPEC-TEST-HOOKS.md` — normative spec for the thread-local test hooks
+//!
+//! Two public macros, both attribute-form:
+//!
+//! - [`macro@cpu_tier`] — attaches `#[target_feature]` + `#[cfg(target_arch)]` + `#[inline]`
+//!   to a function. User owns the feature string; arch inferred from feature names.
+//! - [`macro@chain`] — declares a trampoline chain. Applied to an empty-body function;
+//!   attribute args carry per-arch tier lists with their feature strings inline.
+//!   Each tier's cache miss falls through to the next tier down; chain bottoms out
+//!   at `default`.
+//!
+//! Status: **draft implementation, pending review.** Both macros expand end-to-end
+//! on x86_64, aarch64, and wasm32. Test hooks (thread-local `force_max_tier`) are
+//! emitted behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`.
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{
+    Error, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, LitStr, MetaNameValue, Pat, PatType, Result,
+    Token,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    spanned::Spanned,
+};
+
+// =============================================================================
+// Arch inference table
+// =============================================================================
+//
+// Feature names in this table unambiguously belong to exactly one target_arch.
+// Features that appear on multiple arches (e.g. `aes`, `sha2`, `sha3`, `crc`,
+// `fp16`) are intentionally omitted — they do not drive inference. If every
+// feature in a user's `enable = "..."` list is ambiguous or unknown, inference
+// fails with a compile error pointing at the explicit `arch = "..."` override.
+
+const UNAMBIGUOUS_FEATURES: &[(&str, &str)] = &[
+    // x86_64
+    ("sse", "x86_64"),
+    ("sse2", "x86_64"),
+    ("sse3", "x86_64"),
+    ("ssse3", "x86_64"),
+    ("sse4.1", "x86_64"),
+    ("sse4.2", "x86_64"),
+    ("popcnt", "x86_64"),
+    ("avx", "x86_64"),
+    ("avx2", "x86_64"),
+    ("fma", "x86_64"),
+    ("bmi1", "x86_64"),
+    ("bmi2", "x86_64"),
+    ("lzcnt", "x86_64"),
+    ("f16c", "x86_64"),
+    ("movbe", "x86_64"),
+    ("cmpxchg16b", "x86_64"),
+    ("pclmulqdq", "x86_64"),
+    ("avx512f", "x86_64"),
+    ("avx512bw", "x86_64"),
+    ("avx512cd", "x86_64"),
+    ("avx512dq", "x86_64"),
+    ("avx512vl", "x86_64"),
+    ("avx512vnni", "x86_64"),
+    ("avx512vbmi", "x86_64"),
+    ("avx512vbmi2", "x86_64"),
+    ("avx512ifma", "x86_64"),
+    ("avx512bitalg", "x86_64"),
+    ("avx512vpopcntdq", "x86_64"),
+    ("avx512fp16", "x86_64"),
+    ("avx512bf16", "x86_64"),
+    ("vpclmulqdq", "x86_64"),
+    ("vaes", "x86_64"),
+    ("gfni", "x86_64"),
+    // aarch64
+    ("neon", "aarch64"),
+    ("rdm", "aarch64"),
+    ("dotprod", "aarch64"),
+    ("fhm", "aarch64"),
+    ("fcma", "aarch64"),
+    ("i8mm", "aarch64"),
+    ("bf16", "aarch64"),
+    ("sve", "aarch64"),
+    ("sve2", "aarch64"),
+    ("pmull", "aarch64"),
+    // wasm32
+    ("simd128", "wasm32"),
+    ("relaxed-simd", "wasm32"),
+];
+
+fn infer_arch(features: &str, span: Span) -> Result<&'static str> {
+    for feat in features.split(',') {
+        let feat = feat.trim();
+        for (name, arch) in UNAMBIGUOUS_FEATURES {
+            if *name == feat {
+                return Ok(arch);
+            }
+        }
+    }
+    Err(Error::new(
+        span,
+        format!(
+            "cannot infer target_arch from features `{features}`: all listed features \
+             are ambiguous or unknown to artisan-macros. Add explicit \
+             `arch = \"x86_64\" | \"aarch64\" | \"wasm32\"` to the `#[cpu_tier]` attribute."
+        ),
+    ))
+}
+
+fn split_features(features: &str) -> Vec<String> {
+    features
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Canonicalise a feature string so two declarations with the same feature set
+/// but different ordering / whitespace / duplicates produce the same normalized
+/// form. Used by `#[cpu_tier]` (emits the normalized string as a const) and
+/// `#[chain]` (compares against the const at compile time).
+fn normalize_features(features: &str) -> String {
+    let mut parts: Vec<String> = features
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    parts.sort();
+    parts.dedup();
+    parts.join(",")
+}
+
+/// Construct the hidden const ident that `#[cpu_tier]` emits alongside each
+/// decorated function. `#[chain]` generates an assertion referencing this
+/// ident, so both macros must produce the same mangled name for a given fn.
+fn cpu_tier_feats_const_ident(fn_name: &Ident) -> Ident {
+    format_ident!("__ARTISAN_CPU_TIER_FEATS_{}", fn_name)
+}
+
+// =============================================================================
+// #[cpu_tier] — attach #[target_feature] + #[cfg(target_arch)] + #[inline]
+// =============================================================================
+
+/// Attach `#[target_feature(enable = "...")]` and the inferred `#[cfg(target_arch)]`
+/// to a function.
+///
+/// ```ignore
+/// #[cpu_tier(enable = "avx2,fma,bmi1,bmi2")]
+/// fn compute_v3(data: &[f32]) -> f32 { /* AVX2+FMA body */ }
+/// ```
+///
+/// Emits:
+///
+/// ```ignore
+/// #[cfg(target_arch = "x86_64")]
+/// #[target_feature(enable = "avx2,fma,bmi1,bmi2")]
+/// #[inline]
+/// fn compute_v3(data: &[f32]) -> f32 { /* ... */ }
+/// ```
+///
+/// The generated function is `fn`, not `unsafe fn` (Rust 2024 edition rule). This
+/// keeps `#![forbid(unsafe_code)]` working for downstream crates.
+///
+/// See `SPEC-CPU-TIER.md` for the full normative specification.
+#[proc_macro_attribute]
+pub fn cpu_tier(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match expand_cpu_tier(attr, item) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+struct CpuTierArgs {
+    enable: String,
+    enable_span: Span,
+    arch: Option<String>,
+}
+
+impl Parse for CpuTierArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let items: Punctuated<MetaNameValue, Token![,]> = Punctuated::parse_terminated(input)?;
+        let mut enable: Option<(String, Span)> = None;
+        let mut arch: Option<String> = None;
+        for item in items {
+            let name = item
+                .path
+                .get_ident()
+                .ok_or_else(|| Error::new_spanned(&item.path, "expected identifier"))?
+                .to_string();
+            let value_span = item.value.span();
+            let value = match &item.value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) => s.value(),
+                other => {
+                    return Err(Error::new_spanned(
+                        other,
+                        "expected string literal (e.g. \"avx2,fma\")",
+                    ));
+                }
+            };
+            match name.as_str() {
+                "enable" => {
+                    if enable.is_some() {
+                        return Err(Error::new(value_span, "`enable` specified twice"));
+                    }
+                    enable = Some((value, value_span));
+                }
+                "arch" => {
+                    if arch.is_some() {
+                        return Err(Error::new(value_span, "`arch` specified twice"));
+                    }
+                    arch = Some(value);
+                }
+                other => {
+                    return Err(Error::new_spanned(
+                        &item.path,
+                        format!("unknown argument `{other}`; expected `enable` or `arch`"),
+                    ));
+                }
+            }
+        }
+        let (enable, enable_span) = enable.ok_or_else(|| {
+            Error::new(
+                Span::call_site(),
+                "missing required `enable = \"...\"` argument",
+            )
+        })?;
+        Ok(Self {
+            enable,
+            enable_span,
+            arch,
+        })
+    }
+}
+
+fn expand_cpu_tier(attr: TokenStream, item: TokenStream) -> Result<TokenStream2> {
+    let args: CpuTierArgs = syn::parse(attr)?;
+    let item_fn: ItemFn = syn::parse(item)?;
+
+    // Reject `unsafe fn` — would break #![forbid(unsafe_code)] for downstream crates.
+    if let Some(u) = &item_fn.sig.unsafety {
+        return Err(Error::new_spanned(
+            u,
+            "#[cpu_tier] expects a safe `fn`, not `unsafe fn`. Rust 2024 edition allows \
+             `#[target_feature]` on safe fns; `unsafe fn` would break \
+             `#![forbid(unsafe_code)]` for downstream crates.",
+        ));
+    }
+
+    let arch = match &args.arch {
+        Some(a) => a.clone(),
+        None => infer_arch(&args.enable, args.enable_span)?.to_string(),
+    };
+
+    if !matches!(
+        arch.as_str(),
+        "x86_64" | "x86" | "aarch64" | "arm" | "wasm32"
+    ) {
+        return Err(Error::new(
+            args.enable_span,
+            format!(
+                "arch `{arch}` is not one of: x86_64, x86, aarch64, arm, wasm32. \
+                 (artisan-macros supports these five target_arch values.)"
+            ),
+        ));
+    }
+
+    let enable = &args.enable;
+    let arch_lit = arch.as_str();
+    let fn_name = &item_fn.sig.ident;
+    let vis = &item_fn.vis;
+    let feats_const_ident = cpu_tier_feats_const_ident(fn_name);
+    let normalized = normalize_features(&args.enable);
+
+    // Emit the decorated fn AND a public hidden const carrying the normalized
+    // feature string. The const is cfg-gated to the same target_arch as the
+    // fn, so references from `#[chain]` resolve only when both are present.
+    //
+    // Visibility: we mirror the fn's visibility so that `use crate::module::fn;`
+    // also brings `__ARTISAN_CPU_TIER_FEATS_fn` into scope (Rust doesn't
+    // auto-import consts with fns, but same-module references work without
+    // explicit imports).
+    Ok(quote! {
+        #[cfg(target_arch = #arch_lit)]
+        #[target_feature(enable = #enable)]
+        #[inline]
+        #item_fn
+
+        #[cfg(target_arch = #arch_lit)]
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        #vis const #feats_const_ident: &str = #normalized;
+    })
+}
+
+// =============================================================================
+// #[chain] — declare a trampoline chain
+// =============================================================================
+
+/// Declare a trampoline chain. Applied to an empty-body function; the macro
+/// reads the signature and fills in the body with per-arch dispatch logic.
+///
+/// ```ignore
+/// #[chain(
+///     x86_64 = [
+///         compute_v3 = "avx2,fma,bmi1,bmi2,f16c,lzcnt,popcnt,movbe",
+///         compute_v2 = "sse4.2,popcnt",
+///     ],
+///     aarch64 = [
+///         compute_neon = "neon",
+///     ],
+///     default = compute_scalar,
+/// )]
+/// pub fn compute(data: &[f32]) -> f32 {}
+/// ```
+///
+/// Emits one trampoline per tier (each with its own `AtomicU8` cache), plus the
+/// entry function body with compile-time arch dispatch and compile-time
+/// feature-elision fast paths. Behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`,
+/// also emits a thread-local `force_max_tier` scope and per-chain tier enum.
+///
+/// Tier order in each arch list is highest-to-lowest. Feature strings inline at
+/// the chain site must match the corresponding `#[cpu_tier(enable = "...")]` on
+/// each tier function — see `SPEC-CHAIN.md` § "Feature-string duplication" for the
+/// auditability rationale and failure modes.
+///
+/// See `SPEC-CHAIN.md` and `SPEC-TEST-HOOKS.md` for the full normative expansion.
+#[proc_macro_attribute]
+pub fn chain(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match expand_chain(attr, item) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+struct ChainArgs {
+    arches: Vec<ArchEntry>,
+    default: Ident,
+}
+
+struct ArchEntry {
+    arch: Ident,
+    tiers: Vec<TierEntry>,
+}
+
+struct TierEntry {
+    fn_name: Ident,
+    features: String,
+    features_span: Span,
+}
+
+impl Parse for ChainArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut arches: Vec<ArchEntry> = Vec::new();
+        let mut default: Option<Ident> = None;
+
+        while !input.is_empty() {
+            let name: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            if name == "default" {
+                let fn_name: Ident = input.parse()?;
+                if default.is_some() {
+                    return Err(Error::new(name.span(), "multiple `default = ...` entries"));
+                }
+                default = Some(fn_name);
+            } else {
+                let content;
+                syn::bracketed!(content in input);
+                let mut tiers = Vec::new();
+                while !content.is_empty() {
+                    let fn_name: Ident = content.parse()?;
+                    content.parse::<Token![=]>()?;
+                    let features_lit: LitStr = content.parse()?;
+                    tiers.push(TierEntry {
+                        fn_name,
+                        features: features_lit.value(),
+                        features_span: features_lit.span(),
+                    });
+                    if content.is_empty() {
+                        break;
+                    }
+                    content.parse::<Token![,]>()?;
+                }
+                if tiers.is_empty() {
+                    return Err(Error::new(
+                        name.span(),
+                        format!("arch `{name}` has an empty tier list; remove it or add tiers"),
+                    ));
+                }
+                arches.push(ArchEntry { arch: name, tiers });
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        let default = default.ok_or_else(|| {
+            Error::new(
+                Span::call_site(),
+                "missing required `default = <fn_name>` entry",
+            )
+        })?;
+
+        Ok(Self { arches, default })
+    }
+}
+
+fn detect_macro_for(arch: &str, span: Span) -> Result<TokenStream2> {
+    match arch {
+        "x86_64" | "x86" => Ok(quote! { ::std::is_x86_feature_detected }),
+        "aarch64" => Ok(quote! { ::std::is_aarch64_feature_detected }),
+        "arm" => Ok(quote! { ::std::is_arm_feature_detected }),
+        "wasm32" => Err(Error::new(
+            span,
+            "wasm32 has no runtime feature detection; SIMD tiers on wasm must rely on \
+             compile-time features only. For now, put the tier function directly in the \
+             compile-time elision path via `#[cpu_tier]` and call it from `default` when \
+             `simd128` is not enabled at compile time.",
+        )),
+        other => Err(Error::new(
+            span,
+            format!(
+                "unsupported arch `{other}` in #[chain]: expected x86_64, x86, aarch64, or arm"
+            ),
+        )),
+    }
+}
+
+fn extract_arg_idents(sig: &syn::Signature) -> Result<Vec<Ident>> {
+    let mut out = Vec::with_capacity(sig.inputs.len());
+    for arg in &sig.inputs {
+        match arg {
+            FnArg::Typed(PatType { pat, .. }) => {
+                if let Pat::Ident(pi) = &**pat {
+                    if pi.by_ref.is_some() || pi.mutability.is_some() || pi.subpat.is_some() {
+                        return Err(Error::new_spanned(
+                            pi,
+                            "#[chain] expects simple `name: Type` parameters (no `ref`, no `mut` binding, no subpatterns)",
+                        ));
+                    }
+                    out.push(pi.ident.clone());
+                } else {
+                    return Err(Error::new_spanned(
+                        pat,
+                        "#[chain] expects simple `name: Type` parameters (no destructuring)",
+                    ));
+                }
+            }
+            FnArg::Receiver(r) => {
+                return Err(Error::new_spanned(
+                    r,
+                    "#[chain] cannot be applied to methods with `self` receivers; apply to a free function",
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn mangle_chain_ident(fn_name: &Ident, arch: &str, tier_fn: &Ident) -> Ident {
+    format_ident!("__artisan_{}__{}__{}__chain", fn_name, arch, tier_fn)
+}
+
+fn tier_variant_ident(tier_fn: &Ident, fn_name: &Ident) -> Ident {
+    // Strip the chain's fn_name prefix from the tier fn name if present, uppercase
+    // the rest. e.g. fn_name=compute, tier_fn=compute_v3 -> V3. If no common prefix,
+    // use the whole tier fn name uppercased.
+    let tier_str = tier_fn.to_string();
+    let prefix = format!("{fn_name}_");
+    let stripped = tier_str.strip_prefix(&prefix).unwrap_or(&tier_str);
+    // Uppercase first letter, keep the rest. Avoid making this fancy.
+    let mut chars = stripped.chars();
+    let upper = match chars.next() {
+        Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => stripped.to_string(),
+    };
+    format_ident!("{}", upper)
+}
+
+fn expand_chain(attr: TokenStream, item: TokenStream) -> Result<TokenStream2> {
+    let args: ChainArgs = syn::parse(attr)?;
+    let item_fn: ItemFn = syn::parse(item)?;
+
+    if let Some(u) = &item_fn.sig.unsafety {
+        return Err(Error::new_spanned(
+            u,
+            "#[chain] expects a safe `fn`, not `unsafe fn`",
+        ));
+    }
+    if item_fn.sig.asyncness.is_some() {
+        return Err(Error::new_spanned(
+            &item_fn.sig,
+            "#[chain] does not support `async fn` in the current draft",
+        ));
+    }
+    if !item_fn.sig.generics.params.is_empty() {
+        return Err(Error::new_spanned(
+            &item_fn.sig.generics,
+            "#[chain] does not support generic functions in the current draft",
+        ));
+    }
+
+    let attrs = &item_fn.attrs;
+    let vis = &item_fn.vis;
+    let sig = &item_fn.sig;
+    let name = &sig.ident;
+    let inputs = &sig.inputs;
+    let output = &sig.output;
+    let arg_idents = extract_arg_idents(sig)?;
+    let default_fn = &args.default;
+
+    // Validate: no duplicate arch entries, no duplicate tier fn names within an arch
+    {
+        let mut seen_arches = std::collections::HashSet::new();
+        for a in &args.arches {
+            let s = a.arch.to_string();
+            if !seen_arches.insert(s.clone()) {
+                return Err(Error::new(
+                    a.arch.span(),
+                    format!("arch `{s}` listed more than once in #[chain]"),
+                ));
+            }
+            let mut seen_fns = std::collections::HashSet::new();
+            for t in &a.tiers {
+                let fs = t.fn_name.to_string();
+                if !seen_fns.insert(fs.clone()) {
+                    return Err(Error::new(
+                        t.fn_name.span(),
+                        format!(
+                            "tier function `{fs}` listed more than once under arch `{}`",
+                            a.arch
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Build arch-covered cfg list for the fallback branch.
+    let arch_strs: Vec<String> = args.arches.iter().map(|a| a.arch.to_string()).collect();
+    let not_any_cfg = if arch_strs.is_empty() {
+        quote! { all() } // true — no arches declared, default always
+    } else {
+        let arch_strs = arch_strs.iter();
+        quote! { not(any(#(target_arch = #arch_strs),*)) }
+    };
+
+    // Per-arch dispatch blocks for the entry function.
+    let mut arch_dispatch_blocks: Vec<TokenStream2> = Vec::new();
+    // Per-arch chain trampolines (emitted outside the entry fn).
+    let mut trampolines: Vec<TokenStream2> = Vec::new();
+    // Test-hooks shared state (thread-local + enum + scope) for all tiers across all arches.
+    let mut hook_variants: Vec<Ident> = Vec::new();
+    // Per-arch compile-time equality assertion blocks. Each block verifies that
+    // every tier's feature string in the chain matches the const emitted by
+    // that tier's `#[cpu_tier]` decoration. Gated by target_arch so references
+    // to the per-arch consts resolve only on matching arches.
+    let mut feature_check_blocks: Vec<TokenStream2> = Vec::new();
+
+    for arch_entry in &args.arches {
+        let arch_name = arch_entry.arch.to_string();
+        let arch_str = arch_name.as_str();
+        let detect = detect_macro_for(arch_str, arch_entry.arch.span())?;
+
+        // Build per-tier chain trampolines.
+        for (i, tier) in arch_entry.tiers.iter().enumerate() {
+            let this_fn = &tier.fn_name;
+            let this_chain = mangle_chain_ident(name, arch_str, this_fn);
+            let features = split_features(&tier.features);
+            if features.is_empty() {
+                return Err(Error::new(
+                    tier.features_span,
+                    format!("empty feature list for tier `{this_fn}`"),
+                ));
+            }
+            let next_call: TokenStream2 = if i + 1 < arch_entry.tiers.len() {
+                let next_fn = &arch_entry.tiers[i + 1].fn_name;
+                let next_chain = mangle_chain_ident(name, arch_str, next_fn);
+                quote! { #next_chain(#(#arg_idents),*) }
+            } else {
+                quote! { #default_fn(#(#arg_idents),*) }
+            };
+            let feature_checks = features.iter().map(|f| {
+                quote! { #detect!(#f) }
+            });
+
+            // The tier variant name (for test-hooks enum)
+            let variant = tier_variant_ident(this_fn, name);
+            hook_variants.push(variant.clone());
+
+            // Thread-local forced-max-tier override. Consulted BEFORE the atomic
+            // cache. If override points at a tier lower than this one, fall
+            // through to next_call without touching the cache.
+            let variant_u8_index = (hook_variants.len() as u8) - 1;
+            let cell_path = hook_cell_path(name);
+            let forced_check = quote! {
+                #[cfg(any(test, feature = "artisan_test_hooks"))]
+                {
+                    let forced: ::core::option::Option<u8> = #cell_path.with(|c| c.get());
+                    if let ::core::option::Option::Some(max_idx) = forced {
+                        if (#variant_u8_index) < max_idx {
+                            return #next_call;
+                        }
+                    }
+                }
+            };
+
+            trampolines.push(quote! {
+                #[cfg(target_arch = #arch_str)]
+                #[inline]
+                #[allow(non_snake_case)]
+                fn #this_chain(#inputs) #output {
+                    #forced_check
+                    use ::core::sync::atomic::{AtomicU8, Ordering};
+                    static CACHE: AtomicU8 = AtomicU8::new(0);
+                    match CACHE.load(Ordering::Relaxed) {
+                        2u8 => unsafe { #this_fn(#(#arg_idents),*) },
+                        1u8 => #next_call,
+                        _ => {
+                            let ok = #(#feature_checks)&&*;
+                            CACHE.store(if ok { 2u8 } else { 1u8 }, Ordering::Relaxed);
+                            if ok {
+                                unsafe { #this_fn(#(#arg_idents),*) }
+                            } else {
+                                #next_call
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Entry arch block: compile-time elision for the top tier, fallback to
+        // the top tier's chain trampoline.
+        let top = &arch_entry.tiers[0];
+        let top_fn = &top.fn_name;
+        let top_features = split_features(&top.features);
+        let top_feature_cfgs: Vec<TokenStream2> = top_features
+            .iter()
+            .map(|f| quote! { target_feature = #f })
+            .collect();
+        let top_chain = mangle_chain_ident(name, arch_str, top_fn);
+
+        arch_dispatch_blocks.push(quote! {
+            #[cfg(target_arch = #arch_str)]
+            {
+                #[cfg(all(#(#top_feature_cfgs),*))]
+                { unsafe { #top_fn(#(#arg_idents),*) } }
+                #[cfg(not(all(#(#top_feature_cfgs),*)))]
+                { #top_chain(#(#arg_idents),*) }
+            }
+        });
+
+        // Compile-time feature-string equality check for this arch.
+        // Emits one assertion per tier comparing the chain-site normalized
+        // feature string against the const emitted by `#[cpu_tier]` on the
+        // tier function. Catches drift between the two declarations.
+        let assertions: Vec<TokenStream2> = arch_entry
+            .tiers
+            .iter()
+            .map(|tier| {
+                let tier_fn = &tier.fn_name;
+                let expected_const = cpu_tier_feats_const_ident(tier_fn);
+                let normalized = normalize_features(&tier.features);
+                let err_msg = format!(
+                    "artisan-macros feature-string mismatch for tier `{tier_fn}` on arch `{arch_str}`:\n  \
+                     chain site declares (normalized): {normalized}\n  \
+                     cpu_tier declares (normalized):   (see const {expected_const})\n  \
+                     Both strings must be equal after normalization (sort+dedupe+trim).\n  \
+                     Fix: make the feature strings in #[cpu_tier(enable=\"...\")] and \
+                     #[chain(... = \"...\")] list the same features."
+                );
+                quote! {
+                    {
+                        const CHAIN_SITE: &str = #normalized;
+                        const fn __artisan_str_eq(a: &str, b: &str) -> bool {
+                            let a = a.as_bytes();
+                            let b = b.as_bytes();
+                            if a.len() != b.len() { return false; }
+                            let mut i = 0usize;
+                            while i < a.len() {
+                                if a[i] != b[i] { return false; }
+                                i += 1;
+                            }
+                            true
+                        }
+                        assert!(__artisan_str_eq(#expected_const, CHAIN_SITE), #err_msg);
+                    }
+                }
+            })
+            .collect();
+
+        feature_check_blocks.push(quote! {
+            #[cfg(target_arch = #arch_str)]
+            const _: () = {
+                #(#assertions)*
+            };
+        });
+    }
+
+    // Test-hooks: emit once per chain. If no tiers at all, skip.
+    let test_hooks = if hook_variants.is_empty() {
+        quote! {}
+    } else {
+        build_test_hooks(name, &hook_variants)
+    };
+
+    let fallback_expr = quote! { #default_fn(#(#arg_idents),*) };
+
+    // The function body is a sequence of cfg-gated block expressions where
+    // exactly one compiles for any given target_arch. The compiled block's
+    // value is the tail expression of the fn body.
+    let expansion = quote! {
+        #(#attrs)*
+        #vis fn #name(#inputs) #output {
+            #(#arch_dispatch_blocks)*
+            #[cfg(#not_any_cfg)]
+            { #fallback_expr }
+        }
+
+        #(#trampolines)*
+
+        #(#feature_check_blocks)*
+
+        #test_hooks
+    };
+
+    Ok(expansion)
+}
+
+// =============================================================================
+// Test hooks (thread-local force_max_tier scope + per-chain tier enum)
+// =============================================================================
+//
+// Gated behind `#[cfg(any(test, feature = "artisan_test_hooks"))]`. Users who
+// want to invoke force_max_tier from tests in downstream crates need to enable
+// the `artisan_test_hooks` feature on the crate that owns the #[chain]
+// declaration. Unit tests inside the declaring crate get it automatically
+// via cfg(test).
+
+fn hook_mod_ident(name: &Ident) -> Ident {
+    format_ident!("__artisan_{}_hooks", name)
+}
+
+fn hook_cell_path(name: &Ident) -> TokenStream2 {
+    let m = hook_mod_ident(name);
+    quote! { #m::FORCED_MAX_TIER }
+}
+
+fn build_test_hooks(name: &Ident, variants: &[Ident]) -> TokenStream2 {
+    let mod_ident = hook_mod_ident(name);
+    let capitalized = {
+        let s = name.to_string();
+        let mut it = s.chars();
+        match it.next() {
+            Some(c) => c.to_ascii_uppercase().to_string() + it.as_str(),
+            None => s,
+        }
+    };
+    let enum_ident = format_ident!("{}Tier", capitalized);
+    let scope_ident = format_ident!("{}Scope", capitalized);
+    let force_fn_ident = format_ident!("{}_force_max_tier", name);
+
+    // Variant indices: 0 = first declared (highest), ascending = lower tiers.
+    // We also append `Default` as one past the last, so forcing Default disables
+    // every tier.
+    let variant_arms: Vec<TokenStream2> = variants
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let idx = i as u8;
+            quote! { #enum_ident::#v => #idx }
+        })
+        .collect();
+    let default_idx = variants.len() as u8;
+
+    let variant_defs = variants.iter();
+
+    quote! {
+        #[cfg(any(test, feature = "artisan_test_hooks"))]
+        #[doc(hidden)]
+        pub mod #mod_ident {
+            ::std::thread_local! {
+                pub(super) static FORCED_MAX_TIER: ::core::cell::Cell<::core::option::Option<u8>>
+                    = const { ::core::cell::Cell::new(::core::option::Option::None) };
+            }
+        }
+
+        /// Test-hook tier enum for this chain. Variants listed in declared
+        /// order across all arches (highest tier first), plus `Default` as the
+        /// no-SIMD fallback.
+        #[cfg(any(test, feature = "artisan_test_hooks"))]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum #enum_ident {
+            #(#variant_defs,)*
+            Default,
+        }
+
+        /// RAII scope guard returned by [`#force_fn_ident`]. Dropping restores the
+        /// previous forced-max-tier setting on the current thread.
+        #[cfg(any(test, feature = "artisan_test_hooks"))]
+        #[must_use = "dropping the TierScope immediately restores the previous override"]
+        pub struct #scope_ident {
+            prev: ::core::option::Option<u8>,
+        }
+
+        #[cfg(any(test, feature = "artisan_test_hooks"))]
+        impl ::core::ops::Drop for #scope_ident {
+            fn drop(&mut self) {
+                #mod_ident::FORCED_MAX_TIER.with(|c| c.set(self.prev));
+            }
+        }
+
+        /// Force this chain to dispatch no higher than `tier` on the current
+        /// thread. Returns an RAII guard; drop to restore.
+        ///
+        /// Sound because this can only DISABLE tiers the CPU supports, never
+        /// fabricate tiers the CPU lacks. See `SPEC-TEST-HOOKS.md` for the
+        /// concurrency and soundness properties.
+        #[cfg(any(test, feature = "artisan_test_hooks"))]
+        pub fn #force_fn_ident(tier: #enum_ident) -> #scope_ident {
+            let idx: u8 = match tier {
+                #(#variant_arms,)*
+                #enum_ident::Default => #default_idx,
+            };
+            let prev = #mod_ident::FORCED_MAX_TIER.with(|c| c.replace(::core::option::Option::Some(idx)));
+            #scope_ident { prev }
+        }
+    }
+}

--- a/artisan-macros/src/lib.rs
+++ b/artisan-macros/src/lib.rs
@@ -416,10 +416,16 @@ impl Parse for ChainArgs {
 }
 
 fn detect_macro_for(arch: &str, span: Span) -> Result<TokenStream2> {
+    // Paths are routed through `::std::arch::` rather than `::std::` directly.
+    // The bare `::std::is_aarch64_feature_detected!` path, while documented as
+    // re-exported at std root, fails to resolve under some cross-compile
+    // configurations (observed on cross aarch64-unknown-linux-gnu via CI);
+    // the `std::arch::` path is the one archmage itself uses and it works
+    // consistently across all hosts/targets we care about.
     match arch {
-        "x86_64" | "x86" => Ok(quote! { ::std::is_x86_feature_detected }),
-        "aarch64" => Ok(quote! { ::std::is_aarch64_feature_detected }),
-        "arm" => Ok(quote! { ::std::is_arm_feature_detected }),
+        "x86_64" | "x86" => Ok(quote! { ::std::arch::is_x86_feature_detected }),
+        "aarch64" => Ok(quote! { ::std::arch::is_aarch64_feature_detected }),
+        "arm" => Ok(quote! { ::std::arch::is_arm_feature_detected }),
         "wasm32" => Err(Error::new(
             span,
             "wasm32 has no runtime feature detection; SIMD tiers on wasm must rely on \

--- a/artisan-macros/tests/expand.rs
+++ b/artisan-macros/tests/expand.rs
@@ -1,0 +1,220 @@
+//! Macro-expansion snapshot tests.
+//!
+//! Each `tests/expand/*.rs` file is an input; its `.expanded.rs` sibling is
+//! the committed snapshot of what artisan-macros expands it into. This test
+//! drives `macrotest` over the glob and fails if any expansion drifts.
+//!
+//! Each snapshot has the original input source pinned to the top as a
+//! commented-out block between `// === INPUT ===` and `// === END INPUT ===`
+//! markers, so a reviewer can see input + expansion in a single file without
+//! tab-switching.
+//!
+//! ## Regenerating
+//!
+//! ```text
+//! MACROTEST=overwrite cargo test -p artisan-macros --test expand
+//! ```
+//!
+//! The overwrite pass runs macrotest, then prepends each input file's source
+//! to the generated `.expanded.rs`. Commit all `*.expanded.rs` changes in
+//! the same diff as the macro change.
+//!
+//! ## Requires cargo-expand
+//!
+//! `macrotest` shells out to `cargo expand`. Install with
+//! `cargo install cargo-expand --locked`; CI does this.
+//!
+//! ## x86_64-only
+//!
+//! `cargo expand` resolves `#[cfg(target_arch = "...")]` against the host
+//! target BEFORE printing. Committed snapshots are therefore x86_64-resolved;
+//! the test is gated on `target_arch = "x86_64"`. Aarch64 and wasm32 code
+//! paths are covered by the cross-compile CI jobs (which test the macros
+//! directly; snapshots are for shape, not coverage).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INPUT_START: &str = "// === INPUT ===";
+const INPUT_END: &str = "// === END INPUT ===";
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn snapshots() {
+    let overwrite = std::env::var("MACROTEST").as_deref() == Ok("overwrite");
+
+    // Run macrotest first. In overwrite mode it regenerates snapshots without
+    // the input prefix; we add the prefix in our post-process step below.
+    // In compare mode, macrotest compares against the committed snapshots
+    // (which already have the prefix). For that comparison to succeed, the
+    // committed snapshots must be post-processed — and the
+    // verify_snapshots_have_input_prefix pass below enforces that invariant.
+    //
+    // Order matters: under overwrite, macrotest regenerates FIRST, then we
+    // prepend. Under compare, macrotest compares FIRST (against prefixed
+    // snapshots), which would always fail because macrotest's own rendering
+    // has no prefix. Hence in compare mode we temporarily strip prefixes
+    // before calling macrotest::expand — see run_macrotest_compare below.
+    if overwrite {
+        macrotest::expand("tests/expand/*.rs");
+        postprocess_all_snapshots();
+    } else {
+        run_macrotest_compare();
+        verify_snapshots_have_input_prefix();
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[test]
+fn snapshots_are_x86_64_only() {
+    println!("expansion snapshots are x86_64-only; skipping on this host");
+}
+
+fn input_files() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir("tests/expand").expect("tests/expand must exist") {
+        let path = entry.expect("readable dir entry").path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        if name.ends_with(".rs") && !name.ends_with(".expanded.rs") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn expanded_path_for(input: &Path) -> PathBuf {
+    let stem = input.file_stem().and_then(|s| s.to_str()).unwrap();
+    input.with_file_name(format!("{stem}.expanded.rs"))
+}
+
+fn build_prefix(input_source: &str) -> String {
+    let mut out = String::new();
+    out.push_str(INPUT_START);
+    out.push('\n');
+    for line in input_source.lines() {
+        if line.is_empty() {
+            out.push_str("//");
+            out.push('\n');
+        } else {
+            out.push_str("// ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out.push_str(INPUT_END);
+    out.push('\n');
+    out.push('\n');
+    out
+}
+
+fn strip_existing_prefix(content: &str) -> &str {
+    if let Some(rest) = content.strip_prefix(INPUT_START) {
+        // Trim leading newline after INPUT_START, then look for END marker.
+        let rest = rest.strip_prefix('\n').unwrap_or(rest);
+        if let Some(idx) = rest.find(INPUT_END) {
+            let after_marker = &rest[idx + INPUT_END.len()..];
+            // Skip the newline that follows INPUT_END and any blank line.
+            let after_marker = after_marker.strip_prefix('\n').unwrap_or(after_marker);
+            let after_marker = after_marker.strip_prefix('\n').unwrap_or(after_marker);
+            return after_marker;
+        }
+    }
+    content
+}
+
+fn postprocess_all_snapshots() {
+    for input in input_files() {
+        let expanded = expanded_path_for(&input);
+        if !expanded.exists() {
+            continue;
+        }
+        let input_source = fs::read_to_string(&input).expect("read input");
+        let current = fs::read_to_string(&expanded).expect("read expanded");
+        let body = strip_existing_prefix(&current);
+        let new = format!("{}{}", build_prefix(&input_source), body);
+        if new != current {
+            fs::write(&expanded, new).expect("write expanded");
+        }
+    }
+}
+
+fn run_macrotest_compare() {
+    // macrotest compares against file contents verbatim. Our committed
+    // snapshots have an input-source prefix that macrotest's fresh rendering
+    // won't match. To let macrotest do its comparison, we stage stripped
+    // copies in a sibling temp directory and point macrotest at them. If
+    // macrotest finds a drift there, propagate the failure.
+    //
+    // For simplicity in the current draft we just strip prefixes in-place,
+    // run macrotest, then restore. If macrotest panics we restore in a
+    // PanicGuard.
+    let inputs = input_files();
+    let pairs: Vec<(PathBuf, String)> = inputs
+        .iter()
+        .filter_map(|input| {
+            let expanded = expanded_path_for(input);
+            if expanded.exists() {
+                let original = fs::read_to_string(&expanded).ok()?;
+                Some((expanded, original))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Write stripped versions.
+    for (path, original) in &pairs {
+        let stripped = strip_existing_prefix(original);
+        if stripped != original.as_str() {
+            fs::write(path, stripped).expect("write stripped snapshot");
+        }
+    }
+
+    // Guard: restore originals on panic or normal exit.
+    struct Restore<'a>(&'a [(PathBuf, String)]);
+    impl Drop for Restore<'_> {
+        fn drop(&mut self) {
+            for (path, original) in self.0 {
+                let _ = fs::write(path, original);
+            }
+        }
+    }
+    let _guard = Restore(&pairs);
+
+    macrotest::expand("tests/expand/*.rs");
+}
+
+fn verify_snapshots_have_input_prefix() {
+    let mut failures = Vec::new();
+    for input in input_files() {
+        let expanded = expanded_path_for(&input);
+        if !expanded.exists() {
+            failures.push(format!(
+                "missing snapshot: {}\n  run MACROTEST=overwrite cargo test -p artisan-macros --test expand to generate",
+                expanded.display()
+            ));
+            continue;
+        }
+        let input_source = fs::read_to_string(&input).expect("read input");
+        let snapshot = fs::read_to_string(&expanded).expect("read expanded");
+        let expected_prefix = build_prefix(&input_source);
+        if !snapshot.starts_with(&expected_prefix) {
+            failures.push(format!(
+                "snapshot {} is missing the input-source prefix, or the prefix doesn't match {}\n  regenerate with: MACROTEST=overwrite cargo test -p artisan-macros --test expand",
+                expanded.display(),
+                input.display()
+            ));
+        }
+    }
+    if !failures.is_empty() {
+        panic!(
+            "expansion snapshot integrity check failed:\n{}",
+            failures.join("\n")
+        );
+    }
+}

--- a/artisan-macros/tests/expand/chain_multi_arch.expanded.rs
+++ b/artisan-macros/tests/expand/chain_multi_arch.expanded.rs
@@ -1,0 +1,160 @@
+// === INPUT ===
+// //! `#[chain]` with multiple arches and multiple tiers per arch. Exercises:
+// //! - two x86_64 tiers (v3 and v2) with chained trampolines
+// //! - one aarch64 tier
+// //! - not_any_cfg fallback path (for riscv64 / s390x / etc.)
+// //! - four tier variants in the test-hook enum, plus Default = 4
+//
+// use artisan_macros::{chain, cpu_tier};
+//
+// fn pixel_scalar(r: u8, g: u8, b: u8) -> u32 {
+//     (r as u32) << 16 | (g as u32) << 8 | (b as u32)
+// }
+//
+// #[cpu_tier(enable = "avx2,fma")]
+// fn pixel_v3(r: u8, g: u8, b: u8) -> u32 {
+//     pixel_scalar(r, g, b)
+// }
+//
+// #[cpu_tier(enable = "sse4.2")]
+// fn pixel_v2(r: u8, g: u8, b: u8) -> u32 {
+//     pixel_scalar(r, g, b)
+// }
+//
+// #[cpu_tier(enable = "neon")]
+// fn pixel_neon(r: u8, g: u8, b: u8) -> u32 {
+//     pixel_scalar(r, g, b)
+// }
+//
+// #[chain(
+//     x86_64 = [
+//         pixel_v3 = "avx2,fma",
+//         pixel_v2 = "sse4.2",
+//     ],
+//     aarch64 = [
+//         pixel_neon = "neon",
+//     ],
+//     default = pixel_scalar,
+// )]
+// pub fn pixel(r: u8, g: u8, b: u8) -> u32 {}
+// === END INPUT ===
+
+//! `#[chain]` with multiple arches and multiple tiers per arch. Exercises:
+//! - two x86_64 tiers (v3 and v2) with chained trampolines
+//! - one aarch64 tier
+//! - not_any_cfg fallback path (for riscv64 / s390x / etc.)
+//! - four tier variants in the test-hook enum, plus Default = 4
+use artisan_macros::{chain, cpu_tier};
+fn pixel_scalar(r: u8, g: u8, b: u8) -> u32 {
+    (r as u32) << 16 | (g as u32) << 8 | (b as u32)
+}
+#[target_feature(enable = "avx2,fma")]
+#[inline]
+fn pixel_v3(r: u8, g: u8, b: u8) -> u32 {
+    pixel_scalar(r, g, b)
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+const __ARTISAN_CPU_TIER_FEATS_pixel_v3: &str = "avx2,fma";
+#[target_feature(enable = "sse4.2")]
+#[inline]
+fn pixel_v2(r: u8, g: u8, b: u8) -> u32 {
+    pixel_scalar(r, g, b)
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+const __ARTISAN_CPU_TIER_FEATS_pixel_v2: &str = "sse4.2";
+pub fn pixel(r: u8, g: u8, b: u8) -> u32 {
+    { { __artisan_pixel__x86_64__pixel_v3__chain(r, g, b) } }
+}
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_pixel__x86_64__pixel_v3__chain(r: u8, g: u8, b: u8) -> u32 {
+    use ::core::sync::atomic::{AtomicU8, Ordering};
+    static CACHE: AtomicU8 = AtomicU8::new(0);
+    match CACHE.load(Ordering::Relaxed) {
+        2u8 => unsafe { pixel_v3(r, g, b) }
+        1u8 => __artisan_pixel__x86_64__pixel_v2__chain(r, g, b),
+        _ => {
+            let ok = (false || ::std_detect::detect::__is_feature_detected::avx2())
+                && (false || ::std_detect::detect::__is_feature_detected::fma());
+            CACHE.store(if ok { 2u8 } else { 1u8 }, Ordering::Relaxed);
+            if ok {
+                unsafe { pixel_v3(r, g, b) }
+            } else {
+                __artisan_pixel__x86_64__pixel_v2__chain(r, g, b)
+            }
+        }
+    }
+}
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_pixel__x86_64__pixel_v2__chain(r: u8, g: u8, b: u8) -> u32 {
+    use ::core::sync::atomic::{AtomicU8, Ordering};
+    static CACHE: AtomicU8 = AtomicU8::new(0);
+    match CACHE.load(Ordering::Relaxed) {
+        2u8 => unsafe { pixel_v2(r, g, b) }
+        1u8 => pixel_scalar(r, g, b),
+        _ => {
+            let ok = false || ::std_detect::detect::__is_feature_detected::sse4_2();
+            CACHE.store(if ok { 2u8 } else { 1u8 }, Ordering::Relaxed);
+            if ok { unsafe { pixel_v2(r, g, b) } } else { pixel_scalar(r, g, b) }
+        }
+    }
+}
+const _: () = {
+    {
+        const CHAIN_SITE: &str = "avx2,fma";
+        const fn __artisan_str_eq(a: &str, b: &str) -> bool {
+            let a = a.as_bytes();
+            let b = b.as_bytes();
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut i = 0usize;
+            while i < a.len() {
+                if a[i] != b[i] {
+                    return false;
+                }
+                i += 1;
+            }
+            true
+        }
+        if !__artisan_str_eq(__ARTISAN_CPU_TIER_FEATS_pixel_v3, CHAIN_SITE) {
+            {
+                ::core::panicking::panic_fmt(
+                    format_args!(
+                        "artisan-macros feature-string mismatch for tier `pixel_v3` on arch `x86_64`:\n  chain site declares (normalized): avx2,fma\n  cpu_tier declares (normalized):   (see const __ARTISAN_CPU_TIER_FEATS_pixel_v3)\n  Both strings must be equal after normalization (sort+dedupe+trim).\n  Fix: make the feature strings in #[cpu_tier(enable=\"...\")] and #[chain(... = \"...\")] list the same features.",
+                    ),
+                );
+            }
+        }
+    }
+    {
+        const CHAIN_SITE: &str = "sse4.2";
+        const fn __artisan_str_eq(a: &str, b: &str) -> bool {
+            let a = a.as_bytes();
+            let b = b.as_bytes();
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut i = 0usize;
+            while i < a.len() {
+                if a[i] != b[i] {
+                    return false;
+                }
+                i += 1;
+            }
+            true
+        }
+        if !__artisan_str_eq(__ARTISAN_CPU_TIER_FEATS_pixel_v2, CHAIN_SITE) {
+            {
+                ::core::panicking::panic_fmt(
+                    format_args!(
+                        "artisan-macros feature-string mismatch for tier `pixel_v2` on arch `x86_64`:\n  chain site declares (normalized): sse4.2\n  cpu_tier declares (normalized):   (see const __ARTISAN_CPU_TIER_FEATS_pixel_v2)\n  Both strings must be equal after normalization (sort+dedupe+trim).\n  Fix: make the feature strings in #[cpu_tier(enable=\"...\")] and #[chain(... = \"...\")] list the same features.",
+                    ),
+                );
+            }
+        }
+    }
+};

--- a/artisan-macros/tests/expand/chain_multi_arch.rs
+++ b/artisan-macros/tests/expand/chain_multi_arch.rs
@@ -1,0 +1,38 @@
+//! `#[chain]` with multiple arches and multiple tiers per arch. Exercises:
+//! - two x86_64 tiers (v3 and v2) with chained trampolines
+//! - one aarch64 tier
+//! - not_any_cfg fallback path (for riscv64 / s390x / etc.)
+//! - four tier variants in the test-hook enum, plus Default = 4
+
+use artisan_macros::{chain, cpu_tier};
+
+fn pixel_scalar(r: u8, g: u8, b: u8) -> u32 {
+    (r as u32) << 16 | (g as u32) << 8 | (b as u32)
+}
+
+#[cpu_tier(enable = "avx2,fma")]
+fn pixel_v3(r: u8, g: u8, b: u8) -> u32 {
+    pixel_scalar(r, g, b)
+}
+
+#[cpu_tier(enable = "sse4.2")]
+fn pixel_v2(r: u8, g: u8, b: u8) -> u32 {
+    pixel_scalar(r, g, b)
+}
+
+#[cpu_tier(enable = "neon")]
+fn pixel_neon(r: u8, g: u8, b: u8) -> u32 {
+    pixel_scalar(r, g, b)
+}
+
+#[chain(
+    x86_64 = [
+        pixel_v3 = "avx2,fma",
+        pixel_v2 = "sse4.2",
+    ],
+    aarch64 = [
+        pixel_neon = "neon",
+    ],
+    default = pixel_scalar,
+)]
+pub fn pixel(r: u8, g: u8, b: u8) -> u32 {}

--- a/artisan-macros/tests/expand/chain_simple.expanded.rs
+++ b/artisan-macros/tests/expand/chain_simple.expanded.rs
@@ -1,0 +1,89 @@
+// === INPUT ===
+// //! Minimal `#[chain]`: one tier on x86_64, scalar default. Exercises:
+// //! - entry fn with compile-time arch switch + compile-time feature elision
+// //! - one trampoline with AtomicU8 cache + thread-local forced-check
+// //! - per-arch feature-string assertion const block
+// //! - test-hook surface: enum, scope, force fn, thread-local
+//
+// use artisan_macros::{chain, cpu_tier};
+//
+// fn run_scalar(data: &[f32]) -> f32 {
+//     data.iter().sum()
+// }
+//
+// #[cpu_tier(enable = "avx2")]
+// fn run_v3(data: &[f32]) -> f32 {
+//     data.iter().sum()
+// }
+//
+// #[chain(
+//     x86_64 = [run_v3 = "avx2"],
+//     default = run_scalar,
+// )]
+// pub fn run(data: &[f32]) -> f32 {}
+// === END INPUT ===
+
+//! Minimal `#[chain]`: one tier on x86_64, scalar default. Exercises:
+//! - entry fn with compile-time arch switch + compile-time feature elision
+//! - one trampoline with AtomicU8 cache + thread-local forced-check
+//! - per-arch feature-string assertion const block
+//! - test-hook surface: enum, scope, force fn, thread-local
+use artisan_macros::{chain, cpu_tier};
+fn run_scalar(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+#[target_feature(enable = "avx2")]
+#[inline]
+fn run_v3(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+const __ARTISAN_CPU_TIER_FEATS_run_v3: &str = "avx2";
+pub fn run(data: &[f32]) -> f32 {
+    { { __artisan_run__x86_64__run_v3__chain(data) } }
+}
+#[inline]
+#[allow(non_snake_case)]
+fn __artisan_run__x86_64__run_v3__chain(data: &[f32]) -> f32 {
+    use ::core::sync::atomic::{AtomicU8, Ordering};
+    static CACHE: AtomicU8 = AtomicU8::new(0);
+    match CACHE.load(Ordering::Relaxed) {
+        2u8 => unsafe { run_v3(data) }
+        1u8 => run_scalar(data),
+        _ => {
+            let ok = false || ::std_detect::detect::__is_feature_detected::avx2();
+            CACHE.store(if ok { 2u8 } else { 1u8 }, Ordering::Relaxed);
+            if ok { unsafe { run_v3(data) } } else { run_scalar(data) }
+        }
+    }
+}
+const _: () = {
+    {
+        const CHAIN_SITE: &str = "avx2";
+        const fn __artisan_str_eq(a: &str, b: &str) -> bool {
+            let a = a.as_bytes();
+            let b = b.as_bytes();
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut i = 0usize;
+            while i < a.len() {
+                if a[i] != b[i] {
+                    return false;
+                }
+                i += 1;
+            }
+            true
+        }
+        if !__artisan_str_eq(__ARTISAN_CPU_TIER_FEATS_run_v3, CHAIN_SITE) {
+            {
+                ::core::panicking::panic_fmt(
+                    format_args!(
+                        "artisan-macros feature-string mismatch for tier `run_v3` on arch `x86_64`:\n  chain site declares (normalized): avx2\n  cpu_tier declares (normalized):   (see const __ARTISAN_CPU_TIER_FEATS_run_v3)\n  Both strings must be equal after normalization (sort+dedupe+trim).\n  Fix: make the feature strings in #[cpu_tier(enable=\"...\")] and #[chain(... = \"...\")] list the same features.",
+                    ),
+                );
+            }
+        }
+    }
+};

--- a/artisan-macros/tests/expand/chain_simple.rs
+++ b/artisan-macros/tests/expand/chain_simple.rs
@@ -1,0 +1,22 @@
+//! Minimal `#[chain]`: one tier on x86_64, scalar default. Exercises:
+//! - entry fn with compile-time arch switch + compile-time feature elision
+//! - one trampoline with AtomicU8 cache + thread-local forced-check
+//! - per-arch feature-string assertion const block
+//! - test-hook surface: enum, scope, force fn, thread-local
+
+use artisan_macros::{chain, cpu_tier};
+
+fn run_scalar(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+
+#[cpu_tier(enable = "avx2")]
+fn run_v3(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+
+#[chain(
+    x86_64 = [run_v3 = "avx2"],
+    default = run_scalar,
+)]
+pub fn run(data: &[f32]) -> f32 {}

--- a/artisan-macros/tests/expand/cpu_tier_basic.expanded.rs
+++ b/artisan-macros/tests/expand/cpu_tier_basic.expanded.rs
@@ -1,0 +1,27 @@
+// === INPUT ===
+// //! `#[cpu_tier]` with unambiguous feature — arch inferred as x86_64 from
+// //! `avx2`. Expected expansion: function gets `#[cfg(target_arch = "x86_64")]`
+// //! + `#[target_feature(enable = "avx2,fma")]` + `#[inline]`; sibling hidden
+// //! const `__ARTISAN_CPU_TIER_FEATS_dot_v3` with the normalized feature string.
+//
+// use artisan_macros::cpu_tier;
+//
+// #[cpu_tier(enable = "avx2,fma")]
+// pub fn dot_v3(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+//     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+// }
+// === END INPUT ===
+
+//! `#[cpu_tier]` with unambiguous feature — arch inferred as x86_64 from
+//! `avx2`. Expected expansion: function gets `#[cfg(target_arch = "x86_64")]`
+//! + `#[target_feature(enable = "avx2,fma")]` + `#[inline]`; sibling hidden
+//! const `__ARTISAN_CPU_TIER_FEATS_dot_v3` with the normalized feature string.
+use artisan_macros::cpu_tier;
+#[target_feature(enable = "avx2,fma")]
+#[inline]
+pub fn dot_v3(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const __ARTISAN_CPU_TIER_FEATS_dot_v3: &str = "avx2,fma";

--- a/artisan-macros/tests/expand/cpu_tier_basic.rs
+++ b/artisan-macros/tests/expand/cpu_tier_basic.rs
@@ -1,0 +1,11 @@
+//! `#[cpu_tier]` with unambiguous feature — arch inferred as x86_64 from
+//! `avx2`. Expected expansion: function gets `#[cfg(target_arch = "x86_64")]`
+//! + `#[target_feature(enable = "avx2,fma")]` + `#[inline]`; sibling hidden
+//! const `__ARTISAN_CPU_TIER_FEATS_dot_v3` with the normalized feature string.
+
+use artisan_macros::cpu_tier;
+
+#[cpu_tier(enable = "avx2,fma")]
+pub fn dot_v3(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}

--- a/artisan-macros/tests/expand/cpu_tier_explicit_arch.expanded.rs
+++ b/artisan-macros/tests/expand/cpu_tier_explicit_arch.expanded.rs
@@ -1,0 +1,17 @@
+// === INPUT ===
+// //! `#[cpu_tier]` with an ambiguous feature (`aes` is on x86 and aarch64) —
+// //! user disambiguates with explicit `arch = "aarch64"`. Expected expansion:
+// //! cfg gates to `aarch64`, target_feature enables just `aes`.
+//
+// use artisan_macros::cpu_tier;
+//
+// #[cpu_tier(enable = "aes", arch = "aarch64")]
+// pub fn crypto_step(data: &[u8; 16]) -> [u8; 16] {
+//     *data
+// }
+// === END INPUT ===
+
+//! `#[cpu_tier]` with an ambiguous feature (`aes` is on x86 and aarch64) —
+//! user disambiguates with explicit `arch = "aarch64"`. Expected expansion:
+//! cfg gates to `aarch64`, target_feature enables just `aes`.
+use artisan_macros::cpu_tier;

--- a/artisan-macros/tests/expand/cpu_tier_explicit_arch.rs
+++ b/artisan-macros/tests/expand/cpu_tier_explicit_arch.rs
@@ -1,0 +1,10 @@
+//! `#[cpu_tier]` with an ambiguous feature (`aes` is on x86 and aarch64) —
+//! user disambiguates with explicit `arch = "aarch64"`. Expected expansion:
+//! cfg gates to `aarch64`, target_feature enables just `aes`.
+
+use artisan_macros::cpu_tier;
+
+#[cpu_tier(enable = "aes", arch = "aarch64")]
+pub fn crypto_step(data: &[u8; 16]) -> [u8; 16] {
+    *data
+}

--- a/artisan-macros/tests/real_kernel.rs
+++ b/artisan-macros/tests/real_kernel.rs
@@ -1,0 +1,164 @@
+//! Real SIMD kernel exercising `#[cpu_tier]` + `#[chain]` end-to-end.
+//!
+//! Sums an `&[f32]` using AVX2 + FMA on x86_64 and NEON on aarch64, falling
+//! back to a scalar loop on any other arch (including during CI if the host
+//! CPU lacks the required features).
+//!
+//! Unlike `tests/smoke.rs` (which uses scalar bodies in every tier), this
+//! test actually calls arch-specific intrinsics. The tier bodies use `unsafe`
+//! for memory loads (raw-pointer intrinsics); `#[cpu_tier]`'s target_feature
+//! attribute makes the value-based intrinsics (_mm256_add_ps, vaddq_f32)
+//! safe to call inside the tier body.
+//!
+//! `#![forbid(unsafe_code)]`-compat is NOT claimed for the tier bodies
+//! themselves — users who want it pull in `safe_unaligned_simd` or similar.
+//! The claim is about the macro expansions (trampoline, entry, test hooks),
+//! which remain forbid-compatible regardless of what tier bodies do.
+
+#![allow(dead_code)]
+
+use artisan_macros::{chain, cpu_tier};
+
+// ---------------- Scalar fallback ----------------
+
+fn sum_scalar(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+
+// ---------------- x86_64 / AVX2+FMA ----------------
+
+#[cpu_tier(enable = "avx2,fma")]
+fn sum_v3(data: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use core::arch::x86_64::*;
+        // Accumulate in an 8-lane vector.
+        let mut acc = _mm256_setzero_ps();
+        let chunks = data.chunks_exact(8);
+        let rem = chunks.remainder();
+        for chunk in chunks {
+            // SAFETY: chunks_exact(8) guarantees 8 f32 values are readable at
+            // chunk.as_ptr(); alignment is unconstrained but _mm256_loadu_ps
+            // tolerates unaligned loads.
+            let v = unsafe { _mm256_loadu_ps(chunk.as_ptr()) };
+            acc = _mm256_add_ps(acc, v);
+        }
+        // Horizontal sum of 8 lanes.
+        let mut tmp = [0f32; 8];
+        // SAFETY: tmp has room for 8 f32 values; _mm256_storeu_ps tolerates
+        // unaligned writes.
+        unsafe { _mm256_storeu_ps(tmp.as_mut_ptr(), acc) };
+        tmp.iter().sum::<f32>() + rem.iter().sum::<f32>()
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = data;
+        unreachable!("sum_v3 is x86_64-only; #[cpu_tier] cfg-gates it out elsewhere")
+    }
+}
+
+// ---------------- aarch64 / NEON ----------------
+
+#[cpu_tier(enable = "neon")]
+fn sum_neon(data: &[f32]) -> f32 {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        // Accumulate in a 4-lane vector.
+        let mut acc = vdupq_n_f32(0.0);
+        let chunks = data.chunks_exact(4);
+        let rem = chunks.remainder();
+        for chunk in chunks {
+            // SAFETY: chunks_exact(4) guarantees 4 f32 values at chunk.as_ptr();
+            // vld1q_f32 takes a *const f32 and accepts unaligned addresses.
+            let v = unsafe { vld1q_f32(chunk.as_ptr()) };
+            acc = vaddq_f32(acc, v);
+        }
+        let lane_sum = vaddvq_f32(acc);
+        lane_sum + rem.iter().sum::<f32>()
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = data;
+        unreachable!("sum_neon is aarch64-only; #[cpu_tier] cfg-gates it out elsewhere")
+    }
+}
+
+// ---------------- Dispatch chain ----------------
+
+#[chain(
+    x86_64 = [
+        sum_v3 = "avx2,fma",
+    ],
+    aarch64 = [
+        sum_neon = "neon",
+    ],
+    default = sum_scalar,
+)]
+/// Sum an `&[f32]` using the best available SIMD tier for the host CPU.
+pub fn sum(data: &[f32]) -> f32 {}
+
+// ---------------- Tests ----------------
+
+fn reference_sum(data: &[f32]) -> f32 {
+    // Kahan-ish reference: the scalar fallback is already iter().sum(), which
+    // matches Rust's standard summation. Using the same reference keeps the
+    // assertion bit-exact.
+    data.iter().sum()
+}
+
+#[test]
+fn sum_matches_scalar_small() {
+    let data: Vec<f32> = (0..4).map(|i| i as f32).collect();
+    assert_eq!(sum(&data), reference_sum(&data));
+}
+
+#[test]
+fn sum_matches_scalar_aligned_block() {
+    let data: Vec<f32> = (0..64).map(|i| (i as f32) * 0.5).collect();
+    assert_eq!(sum(&data), reference_sum(&data));
+}
+
+#[test]
+fn sum_matches_scalar_with_remainder() {
+    // 37 elements: one AVX2 iter (8 * 4 = 32) plus 5 remainder for x86,
+    // nine NEON iters (4 * 9 = 36) plus 1 remainder for aarch64.
+    let data: Vec<f32> = (0..37).map(|i| (i as f32) - 10.0).collect();
+    assert_eq!(sum(&data), reference_sum(&data));
+}
+
+#[test]
+fn sum_matches_scalar_empty() {
+    let data: &[f32] = &[];
+    assert_eq!(sum(data), 0.0);
+}
+
+#[test]
+fn sum_matches_scalar_large() {
+    let n = 10_000;
+    let data: Vec<f32> = (0..n).map(|i| ((i as f32) * 0.001).sin()).collect();
+    // Tolerance: lane-reordering in SIMD sums produces different rounding vs
+    // sequential scalar sum. We accept a tiny relative error.
+    let actual = sum(&data);
+    let expected = reference_sum(&data);
+    let rel = ((actual - expected).abs()) / expected.abs().max(1e-6);
+    assert!(
+        rel < 1e-5,
+        "relative error {rel:.2e} exceeds tolerance (actual={actual}, expected={expected})"
+    );
+}
+
+// ---------------- Test-hook exercise on real tiers ----------------
+
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+#[test]
+fn force_scalar_matches_reference() {
+    let data: Vec<f32> = (0..100).map(|i| (i as f32) * 0.25).collect();
+    {
+        let _scope = sum_force_max_tier(SumTier::Default);
+        // Forced to default — scalar path runs.
+        assert_eq!(sum(&data), reference_sum(&data));
+    }
+    // Normal dispatch resumes.
+    let _ = sum(&data);
+}

--- a/artisan-macros/tests/smoke.rs
+++ b/artisan-macros/tests/smoke.rs
@@ -1,0 +1,98 @@
+//! End-to-end smoke test for `#[cpu_tier]` and `#[chain]`.
+//!
+//! Uses scalar bodies on every tier to verify the dispatch mechanics without
+//! needing real SIMD intrinsics. A real-world user would have hand-written
+//! intrinsics in each tier function — correctness comes from matching output,
+//! not from the dispatch macro itself.
+
+#![allow(dead_code)]
+
+use artisan_macros::{chain, cpu_tier};
+
+// --- Scalar fallback (always available) ---
+fn dot_scalar(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+}
+
+// --- x86_64 tiers ---
+#[cpu_tier(enable = "avx2,fma")]
+fn dot_v3(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    // Real user would write AVX2+FMA intrinsics here.
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+}
+
+#[cpu_tier(enable = "sse4.2")]
+fn dot_v2(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+}
+
+// --- aarch64 tier ---
+#[cpu_tier(enable = "neon")]
+fn dot_neon(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+}
+
+// --- Chain declaration ---
+// DELIBERATE MISMATCH to sanity-check that the compile-time feature-string
+// assertion fires. Flip the `fma` in dot_v3's chain entry to something else
+// and `cargo test` should fail with the artisan-macros mismatch error.
+// Verified manually on 2026-04-20; left in the CANONICAL (matching) form.
+#[chain(
+    x86_64 = [
+        dot_v3 = "avx2,fma",
+        dot_v2 = "sse4.2",
+    ],
+    aarch64 = [
+        dot_neon = "neon",
+    ],
+    default = dot_scalar,
+)]
+/// Public entry. Dispatches to the highest available tier on the host arch,
+/// falling through to `dot_scalar` on uncovered arches or unsupported CPUs.
+pub fn dot(a: &[f32; 4], b: &[f32; 4]) -> f32 {}
+
+#[test]
+fn dispatch_produces_correct_result() {
+    let a = [1.0, 2.0, 3.0, 4.0];
+    let b = [5.0, 6.0, 7.0, 8.0];
+    // 1*5 + 2*6 + 3*7 + 4*8 = 5 + 12 + 21 + 32 = 70
+    assert_eq!(dot(&a, &b), 70.0);
+}
+
+#[test]
+fn dispatch_is_idempotent_across_calls() {
+    let a = [1.0f32; 4];
+    let b = [2.0f32; 4];
+    let expected = 8.0f32;
+    for _ in 0..100 {
+        assert_eq!(dot(&a, &b), expected);
+    }
+}
+
+// The test-hooks block below exercises the thread-local override + RAII scope.
+// Compiles only under `cfg(test)` or `cfg(feature = "artisan_test_hooks")`.
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+#[test]
+fn force_max_tier_scope_compiles_and_isolates() {
+    let a = [1.0, 2.0, 3.0, 4.0];
+    let b = [5.0, 6.0, 7.0, 8.0];
+    let expected = 70.0;
+
+    // Force down to Default (no SIMD). Dispatcher must skip every tier and hit
+    // the scalar fallback.
+    {
+        let _scope = dot_force_max_tier(DotTier::Default);
+        assert_eq!(dot(&a, &b), expected);
+    } // _scope drops, restores previous (None)
+
+    // After scope drop, normal dispatch resumes.
+    assert_eq!(dot(&a, &b), expected);
+}
+
+// Smoke-test that the test-hook types are actually generated and public.
+#[cfg(any(test, feature = "artisan_test_hooks"))]
+#[allow(dead_code)]
+fn _type_surface_check() {
+    let _: DotTier = DotTier::Default;
+    let _scope: DotScope = dot_force_max_tier(DotTier::Default);
+}


### PR DESCRIPTION
## Summary

Draft of `artisan-macros`, a single-file proc-macro crate exploring an alternative to archmage's dispatch macro stack. Two attribute macros (`#[cpu_tier]`, `#[chain]`) plus a thread-local test-hook layer. Convention-forward, user-owned feature strings, no registry, `#![forbid(unsafe_code)]`-compat downstream.

**Do not merge.** This lives on `feat/artisan-macros-draft` and is intentionally isolated from `main` until the design questions in the SPECs and `HANDOFF.md` are resolved.

## What's here

- Single-file impl in `artisan-macros/src/lib.rs` (~840 LoC)
- `#[cpu_tier(enable = "features")]` attaches `#[target_feature]` + inferred `#[cfg(target_arch)]` + `#[inline]`; emits a hidden normalized feature const
- `#[chain(arch = [fn = "features", ...], default = fn)]` generates trampoline chains: per-tier `AtomicU8` tri-state caches, compile-time arch switch, top-tier compile-time feature elision
- Per-chain thread-local `force_max_tier` RAII scope for parity-test isolation (no `#[serial]` or `RUST_TEST_THREADS=1` needed)
- Compile-time feature-string equality check between `#[cpu_tier]` and `#[chain]` — mismatch fails to build with a specific error; verified by deliberate mutation
- 10 passing tests on x86_64: scalar smoke (3), real AVX2+FMA and NEON sum kernel (6), macrotest snapshots (1)
- Committed macro-expansion snapshots under `artisan-macros/tests/expand/`
- Dedicated CI at `.github/workflows/artisan-macros.yml`, path-filtered so archmage main CI is untouched. Matrix: ubuntu/windows/windows-11-arm/macos-26-intel/macos-latest native, i686/aarch64/armv7 cross, clippy (base + `artisan_test_hooks` feature), fmt, docs (`-D warnings`), expansion-drift check, feature-mismatch self-test
- Nine markdown files: `DESIGN.md`, `SPEC-CPU-TIER.md`, `SPEC-CHAIN.md`, `SPEC-TEST-HOOKS.md`, `README.md`, `HANDOFF.md`, plus two unposted archmage GH issue drafts (`PARITY_HARNESS_ISSUE_DRAFT.md`, `ARCHMAGE-THREAD-LOCAL-ISSUE.md`)

## What's not here yet

- `SPEC-CPU-TIER.md` and `SPEC-CHAIN.md` predate the feature-string const — they need a Revisions section documenting the emitted `__ARTISAN_CPU_TIER_FEATS_<fn>` and the `const _: () = { assert!(str_eq(...)) }` blocks
- `#![forbid(unsafe_code)]` downstream verification crate — claim documented, not compiled yet
- Real downstream consumer — archmage itself doesn't use this yet
- First CI run — this push is the trigger

## Test plan

- [ ] CI green on all matrix entries (the interesting ones: windows-11-arm, macos-latest Apple Silicon, aarch64 cross)
- [ ] Feature-string mismatch self-test proves the compile-time check fires on a bad-chain crate
- [ ] Expansion-drift check passes on x86_64 (snapshots are committed)
- [ ] Reviewer reads `HANDOFF.md` first, then `DESIGN.md` + each `SPEC-*.md`; flags the open questions worth resolving before v0.1.0
- [ ] Decide: adopt as archmage's internal dispatch (migration story), keep as separate crate, or discard

See `artisan-macros/HANDOFF.md` for the full review checklist and file inventory.