### PR TITLE
fix(magetypes): honor -scalar in tier list modifiers (#46)

### DIFF
--- a/archmage-macros/src/lib.rs
+++ b/archmage-macros/src/lib.rs
@@ -1082,6 +1082,27 @@ mod tests {
     }
 
     #[test]
+    fn resolve_subtractive_removes_scalar() {
+        // -scalar must actually remove scalar — auto-append must not undo it
+        let tiers = resolve_tier_names(&["-scalar"], true);
+        assert!(
+            !tiers.iter().any(|t| t == "scalar"),
+            "expected scalar to be removed, got {tiers:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_subtractive_removes_scalar_with_other_modifiers() {
+        // [-scalar, +arm_v2] — scalar removed, arm_v2 added, no scalar re-injected
+        let tiers = resolve_tier_names(&["-scalar", "+arm_v2"], true);
+        assert!(
+            !tiers.iter().any(|t| t == "scalar"),
+            "expected scalar to be removed, got {tiers:?}"
+        );
+        assert!(tiers.contains(&"arm_v2".to_string()));
+    }
+
+    #[test]
     fn resolve_mixed_add_remove() {
         let tiers = resolve_tier_names(&["-neon", "-wasm128", "+v1"], true);
         assert!(tiers.contains(&"v1".to_string()));

--- a/archmage-macros/src/magetypes.rs
+++ b/archmage-macros/src/magetypes.rs
@@ -22,7 +22,9 @@ use crate::tiers::*;
 /// `defines` is a list of magetypes type names (e.g. `["f32x8", "u16x16"]`)
 /// to inject as local type aliases at the top of each variant's body:
 ///
-///     type f32x8 = ::magetypes::simd::generic::f32x8<Token>;
+/// ```text
+/// type f32x8 = ::magetypes::simd::generic::f32x8<Token>;
+/// ```
 ///
 /// The alias's `Token` is substituted to the concrete token type for each
 /// tier (same as the rest of the body). This eliminates the boilerplate

--- a/archmage-macros/src/tiers.rs
+++ b/archmage-macros/src/tiers.rs
@@ -303,6 +303,10 @@ pub(crate) fn resolve_tiers(
     // re-apply the descriptor's cfg_feature on them. Writing +v4 means "I want
     // v4 exactly as written, without the automatic avx512 gate."
     let mut user_overrides: Vec<String> = Vec::new();
+    // Tracks whether the user explicitly removed the scalar/default fallback
+    // via `-scalar` or `-default`. Used to suppress the auto-append below so
+    // that `[-scalar]` actually drops the scalar variant.
+    let mut fallback_explicitly_removed = false;
     let effective_names: Vec<String> = if any_modifier {
         let mut names: Vec<String> = DEFAULT_TIER_NAMES.iter().map(|s| s.to_string()).collect();
         for raw in tier_names {
@@ -330,6 +334,9 @@ pub(crate) fn resolve_tiers(
             if is_removal {
                 if let Some(pos) = pos {
                     names.remove(pos);
+                }
+                if is_fallback {
+                    fallback_explicitly_removed = true;
                 }
                 // Removing a tier that's not in defaults is a silent no-op
             } else if let Some(pos) = pos {
@@ -394,7 +401,7 @@ pub(crate) fn resolve_tiers(
         ));
     }
 
-    if !has_scalar && !has_default {
+    if !has_scalar && !has_default && !fallback_explicitly_removed {
         tiers.push(ResolvedTier {
             tier: find_tier("scalar").unwrap(),
             feature_gate: None,


### PR DESCRIPTION
## Summary

Closes #46.

`resolve_tiers` unconditionally auto-appended a `scalar` fallback whenever the resolved tier list contained neither `scalar` nor `default`. That auto-append ran *after* `-scalar` had already removed it in additive mode, silently undoing the removal — making the documented "piecewise tier blocks" pattern in #46 fail with `the name foo_scalar is defined multiple times`.

## Fix

Track whether the user explicitly removed the fallback (`-scalar` or `-default`) in additive mode, and skip the auto-append in that case.

**Non-breaking on purpose:**
- Pure additive lists (`+arm_v2`, `+v1`) — unchanged, defaults still bring in scalar.
- Override mode (`[v3]`, `[v4, neon]`) — unchanged, scalar still auto-appended (would be a breaking change otherwise; per CHANGELOG that auto-append removal is queued for v1.0).
- Only new behavior: explicit `-scalar`/`-default` is now actually honored.

## Resolves the #46 repro

```rust
#[magetypes(define(f32x16), v4, v4x, -scalar)]
fn foo(token: Token, x: &mut [f32]) { /* AVX-512 native f32x16 body */ }

#[magetypes(define(f32x8), v3, neon, wasm128)]
fn foo(token: Token, x: &mut [f32]) { /* AVX2/NEON/WASM SIMD128 native f32x8 body */ }
```

The first block adds `-scalar` to opt out of auto-append; the second block keeps it. No `_scalar` collision.

## Drive-by

Also fixes a rustdoc breakage in `archmage-macros/src/magetypes.rs` where a 4-space-indented snippet in a doc comment was parsed as a runnable doctest referencing `::magetypes::` (a circular dep) and an unbound `Token`. Bisected to `38b0c52` (the v0.9.22 release commit) which added the `define()` documentation. Switched to a fenced ```text``` block.

## Test plan

- [x] New unit tests `resolve_subtractive_removes_scalar` and `resolve_subtractive_removes_scalar_with_other_modifiers` (both fail before, pass after)
- [x] All 11 `resolve_*` tier-resolver tests pass
- [x] All 95 `archmage-macros` lib tests pass
- [x] All 13 `magetypes` lib tests pass
- [x] `archmage-macros` doctest no longer fails