### PR TITLE
chore: lower base MSRV to 1.88 (avx512 + default macro tiers stay 1.89+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,10 +489,100 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
 
   # ==========================================================================
-  # MSRV check — verify advertised MSRV on every platform
+  # MSRV check — verify advertised MSRV on every platform.
+  #
+  # Base MSRV is 1.88: the archmage + magetypes LIBRARIES build and their unit
+  # tests pass on 1.88. The opt-in `avx512` feature, AND the DEFAULT macro
+  # output (`#[autoversion]` / default `#[magetypes]` always include the v4
+  # AVX-512 tier, which emits `#[target_feature(enable="avx512f,...")]` on
+  # x86_64), both require 1.89. So this is split into two jobs: a 1.88 base
+  # job (default-feature library build + lib tests + v4-free downstream usage)
+  # and a 1.89 job (the avx512 feature at its required floor). See MSRV.md.
   # ==========================================================================
-  msrv:
-    name: MSRV 1.89 (${{ matrix.name }})
+  msrv-base:
+    name: MSRV 1.88 base (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, name: x64 Linux }
+          - { os: windows-latest, name: x64 Windows }
+          - { os: macos-26-intel, name: x64 macOS Intel }
+          - { os: ubuntu-24.04-arm, name: aarch64 Linux }
+          - { os: macos-14, name: aarch64 macOS }
+          - { os: windows-11-arm, name: aarch64 Windows }
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Default features (NO avx512). Proves the libraries build on the base MSRV.
+      - name: Build libraries (default features)
+        run: cargo build -p archmage -p magetypes
+
+      # Library unit tests on 1.88. NOTE: the full `cargo test` is NOT run here
+      # because many dev-only integration tests/examples use `#[autoversion]` /
+      # `#[magetypes(v4, ...)]`, whose v4 (AVX-512) variant needs 1.89.
+      - name: Library unit tests (default features)
+        run: cargo test -p archmage -p magetypes --lib
+
+      # v4-free macro usage compiles on 1.88: explicit tier lists that omit the
+      # AVX-512 v4/v4x tiers are the recommended path for 1.88 consumers. Built
+      # from a throwaway crate so it doesn't drag in published deps with their
+      # own (higher) MSRVs.
+      - name: Assert v4-free macro usage compiles on 1.88
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir -p /tmp/v4free/src
+          cat > /tmp/v4free/Cargo.toml <<EOF
+          [package]
+          name = "v4free"
+          version = "0.0.0"
+          edition = "2024"
+          [dependencies]
+          archmage = { path = "$GITHUB_WORKSPACE" }
+          [workspace]
+          EOF
+          cat > /tmp/v4free/src/lib.rs <<'EOF'
+          use archmage::prelude::*;
+          // Explicit tier list WITHOUT v4/v4x — no AVX-512 target_feature, so 1.88-safe.
+          #[autoversion(v3, neon, wasm128)]
+          pub fn dot(_t: SimdToken, a: &[f32], b: &[f32]) -> f32 {
+              a.iter().zip(b).map(|(x, y)| x * y).sum()
+          }
+          EOF
+          cargo build --manifest-path /tmp/v4free/Cargo.toml
+
+      # Negative assertion (x64 Linux only): the DEFAULT macro output includes
+      # the v4 AVX-512 tier, so a bare `#[autoversion]` downstream crate MUST
+      # fail to *compile* on 1.88 (E0658, avx512f unstable). The no-features
+      # crate declares rust-version = 1.89, so `--ignore-rust-version` is used
+      # to bypass the cargo MSRV gate and reach the real codegen error.
+      # Documents the floor — if this ever compiles on 1.88, the
+      # v4-tier-needs-1.89 docs are stale.
+      - name: Assert default-tier (v4) macro output fails to compile on 1.88
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          if cargo build -p archmage-no-features-test --ignore-rust-version 2>build_188.log; then
+            echo "::error::Expected bare #[autoversion] (default tiers incl. v4) to FAIL on 1.88, but it built. MSRV docs may be stale."
+            exit 1
+          fi
+          if ! grep -q 'avx512f' build_188.log; then
+            echo "::error::no-features-crate failed on 1.88 but NOT with the expected avx512f E0658 error:"
+            cat build_188.log
+            exit 1
+          fi
+          echo "OK: bare #[autoversion] fails to compile on 1.88 with avx512f E0658, as documented."
+
+  msrv-avx512:
+    name: MSRV 1.89 avx512 (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -515,7 +605,9 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Check MSRV
+      # The avx512 feature requires 1.89 (its required floor). Also exercises the
+      # default-tier macro output (v4 AVX-512) that needs 1.89.
+      - name: Check avx512 feature at its 1.89 floor
         run: cargo check --features "${{ env.FEATURES }}"
 
       - name: CPU survey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Require explicit `tier(cfg(feature))` syntax — remove implicit `cfg_feature` auto-gating on v4/v4x
 - Make `w512` non-default in magetypes — users who need 512-bit types add `features = ["w512"]`; saves ~25% build time for the majority who don't
 
+### Changed
+
+- Lower base MSRV from 1.89 to **1.88** (workspace + `xtask` + `tests/no-features-crate`). The archmage and magetypes libraries build, and their unit tests pass, on 1.88; v4-free dispatch (explicit tier lists without `v4`/`v4x`, e.g. `#[autoversion(v3, neon, wasm128)]`) also works on 1.88. The opt-in **`avx512` feature** and the **default macro tiers** (`#[autoversion]` / default `#[magetypes]` always include the `v4` AVX-512 tier, which emits `#[target_feature(enable = "avx512f, …")]` regardless of the feature) still require **Rust 1.89+**, where the `avx512f`/`avx512vl` target features stabilized. Lowering the declared MSRV is semver-safe (strictly more permissive). The dev-dependency `safe_unaligned_simd` no longer enables `avx512` unconditionally (it would force the AVX-512 module to compile on 1.88); Cargo re-unifies the feature with the normal dependency when `--features avx512` is set, so avx512-gated tests are unaffected. Docs (`MSRV.md`, README) updated to describe the 1.88-base / 1.89-for-AVX-512 split; CI gains a 1.88 base-MSRV job and a 1.89 avx512 job (replacing the single 1.89 MSRV job).
+
 ## [0.9.24] - 2026-05-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "archmage-macros", "magetypes", "xtask", "tests/no-features-crat
 [workspace.package]
 version = "0.9.24"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imazen/archmage"
 
@@ -40,6 +40,13 @@ std = []
 macros = []
 # AVX-512 token support (Avx512Token, X64V4xToken, X64V4Token, etc.)
 # Also enables AVX-512 safe memory ops from safe_unaligned_simd.
+#
+# Base MSRV is 1.88, but this opt-in feature requires Rust 1.89+: the
+# `avx512f`/`avx512vl` target features stabilized in 1.89, and the
+# `safe_unaligned_simd` avx512 module (pulled in by this feature) uses them.
+# On 1.88, target the AVX2 (`v3`) tier and below — and use explicit, v4-free
+# tier lists, since the DEFAULT macro tiers (`#[autoversion]` / default
+# `#[magetypes]`) include the `v4` AVX-512 tier, which also needs 1.89.
 avx512 = ["safe_unaligned_simd/avx512", "archmage-macros/avx512"]
 # Backwards-compat: safe_unaligned_simd is now always included (no longer optional).
 # This feature exists so `features = ["safe_unaligned_simd"]` doesn't break.
@@ -78,7 +85,14 @@ winarm-cpufeatures = { version = "0.1.2", default-features = false, features = [
 zenbench = { version = "0.1.2", features = ["criterion-compat"] }
 trybuild = "1.0"
 macrotest = "1.2.1"
-safe_unaligned_simd = { version = "0.2.5", features = ["avx512"] }
+# safe_unaligned_simd is a dev-dependency here only so tests can reference its
+# memory ops directly. We do NOT enable its `avx512` feature unconditionally:
+# that module needs Rust 1.89+ (avx512f/avx512vl target features) and would
+# break `cargo test` on the 1.88 base MSRV. When archmage's own `avx512`
+# feature is on, Cargo unifies this dep with the normal-dependency feature set
+# (which chains `safe_unaligned_simd/avx512`), so avx512-gated tests still get
+# the avx512 ops — without forcing them on default 1.88 builds.
+safe_unaligned_simd = { version = "0.2.5" }
 
 [[bench]]
 name = "tokens"

--- a/MSRV.md
+++ b/MSRV.md
@@ -1,6 +1,30 @@
-# How Rust 1.89 brought the safe SIMD story together for Archmage
+# How Rust brought the safe SIMD story together for Archmage
 
-Archmage requires Rust 1.89+. This isn't arbitrary — 1.89 is the version where Rust's SIMD story finally came together. Four releases turned SIMD from "unsafe everything" to "zero unsafe with full feature coverage."
+**Base MSRV: Rust 1.88.** The archmage and magetypes libraries build, and their
+unit tests pass, on Rust 1.88. SIMD dispatch that omits the AVX-512 tiers also
+works on 1.88 — e.g. an explicit tier list like `#[autoversion(v3, neon,
+wasm128)]` or `#[magetypes(v3, neon, wasm128, scalar)]`.
+
+**AVX-512 (the `v4` / `v4x` tiers and the opt-in `avx512` feature) requires Rust
+1.89+.** This is not arbitrary — the `avx512f`/`avx512vl`/… target features
+stabilized in 1.89. Two practical consequences:
+
+- The opt-in **`avx512` feature** requires 1.89 (it also pulls in the
+  `safe_unaligned_simd` AVX-512 module, which uses those target features).
+- **The DEFAULT macro output requires 1.89 on x86_64.** `#[autoversion]` (no
+  args) and a default-tier `#[magetypes]` *always include the `v4` (AVX-512)
+  tier*, and that variant emits `#[target_feature(enable = "avx512f, …")]`
+  regardless of the `avx512` cargo feature. So a downstream crate that writes a
+  bare `#[autoversion] fn …` compiles on 1.89 but not on 1.88. To target 1.88,
+  give the macro an explicit tier list without `v4`/`v4x`.
+
+> Note on tier naming: in archmage, **`v3` is AVX2/FMA** (x86-64-v3) and **`v4`
+> is AVX-512** (x86-64-v4: F+CD+VL+DQ+BW). `v4x` is the extended AVX-512 set.
+> See `token-registry.toml`.
+
+The rest of this document walks through the four releases that turned SIMD from
+"unsafe everything" to "zero unsafe with full feature coverage" — the last of
+which, 1.89, is why AVX-512 needs that version.
 
 ## Rust 1.86 — safe `#[target_feature]` calls (April 2025)
 
@@ -152,4 +176,4 @@ fn main() {
 }
 ```
 
-No `#![feature(...)]`, no `unsafe`, no nightly. `#![forbid(unsafe_code)]` works. That's why the MSRV is 1.89.
+No `#![feature(...)]`, no `unsafe`, no nightly. `#![forbid(unsafe_code)]` works. That's why **AVX-512 needs 1.89** — and why the default macro tiers (which include `v4`) and the `avx512` feature do too. The base MSRV stays at **1.88** for v4-free dispatch.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ Archmage lets you write SIMD code in Rust without `unsafe`. It works on x86-64, 
 archmage = "0.9"
 ```
 
-### MSRV: Rust 1.89 — [How Rust 1.89 brought the safe SIMD story together for Archmage](MSRV.md)
+### MSRV: Rust 1.88 base; AVX-512 needs 1.89 — [How Rust brought the safe SIMD story together for Archmage](MSRV.md)
+
+The libraries build on **Rust 1.88**, as does v4-free dispatch (explicit tier
+lists without `v4`/`v4x`, e.g. `#[autoversion(v3, neon, wasm128)]`). The opt-in
+**`avx512` feature** and the **default macro tiers** (`#[autoversion]` /
+default `#[magetypes]` always include the `v4` AVX-512 tier) require **Rust
+1.89+** — that's where the `avx512f`/`avx512vl`/… target features stabilized.
 
 ## The problem
 

--- a/tests/no-features-crate/Cargo.toml
+++ b/tests/no-features-crate/Cargo.toml
@@ -2,6 +2,11 @@
 name = "archmage-no-features-test"
 version = "0.0.0"
 edition = "2024"
+# Stays at 1.89: this crate uses bare `#[autoversion]`, whose default tier list
+# includes `v4` (AVX-512), so its generated code emits `#[target_feature(enable
+# = "avx512f, …")]` — which needs 1.89 even with no cargo features. It is the
+# fixture the `msrv-base` CI job uses to ASSERT that default-tier macro output
+# fails on 1.88 (see .github/workflows/ci.yml).
 rust-version = "1.89"
 publish = false
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.88"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## What

Lower the workspace base MSRV from **1.89 to 1.88**. Empirically grounded: the `archmage` and `magetypes` libraries build, and their unit tests pass, on Rust 1.88, and v4-free dispatch works there too.

## The 1.88 / 1.89 split (verified locally)

AVX-512 still genuinely requires 1.89 on **two** fronts:

1. **The opt-in `avx512` feature** — `avx512f`/`avx512vl` target features stabilized in 1.89, and the `safe_unaligned_simd` avx512 module (pulled in by the feature) uses them. Dep-floored; cannot be version-gated away from archmage's side.
2. **The DEFAULT macro output** — `#[autoversion]` (no args) and a default-tier `#[magetypes]` *always include the `v4` (AVX-512) tier*, which emits `#[target_feature(enable = "avx512f, …")]` regardless of the cargo feature (`autoversion.rs`: "autoversion always includes v4 … never skips avx512"). So a bare `#[autoversion]` downstream crate compiles on 1.89 but **fails on 1.88** (E0658).

**Net:** 1.88 is the base MSRV for the libraries + **v4-free** dispatch (explicit tier lists without `v4`/`v4x`, e.g. `#[autoversion(v3, neon, wasm128)]`). Default macro usage and the `avx512` feature need 1.89.

> Naming note: in archmage, **`v3` = AVX2/FMA** and **`v4` = AVX-512** (`token-registry.toml`).

## Verification matrix (local, x86_64, toolchains 1.88.0 / 1.89.0)

| Check | Result |
|---|---|
| `cargo +1.88.0 build -p magetypes -p archmage` (default) | pass |
| `cargo +1.88.0 test -p magetypes -p archmage --lib` (default) | pass (4 + 13 tests) |
| `cargo +1.89.0 check -p magetypes --features avx512` | pass |
| `cargo +1.88.0 check -p magetypes --features avx512` | **fails as expected** (E0658, documented) |
| bare `#[autoversion]` on 1.88 | **fails as expected** (E0658) |
| v4-free `#[autoversion(v3, neon, wasm128)]` on 1.88 | pass |
| `cargo +1.89.0 test -p archmage --features avx512` (incl. `safe_memory_ops`) | pass — dev-dep change loses no avx512 coverage |
| `cargo semver-checks` (archmage + magetypes vs 0.9.24) | clean, no break |
| fmt / CI-path clippy (`--features 'std avx512' -- -D warnings`) | clean |

## Changes

- `rust-version` 1.89 → 1.88 on the workspace package + `xtask`. Test fixtures that genuinely need AVX-512 stay at 1.89 (`no-features-crate`, `linear-srgb`, `avx512-cfg-tests/*`).
- Dev-dependency `safe_unaligned_simd` no longer enables `avx512` unconditionally (it forced the AVX-512 module to compile even on a default 1.88 `cargo test`). With `--features avx512`, Cargo re-unifies it via the normal-dep feature chain, so avx512-gated tests are unchanged.
- Docs: `MSRV.md`, `README.md`, and the `avx512` feature comment in `Cargo.toml` describe the split.
- CI: replaced the single `MSRV 1.89` job with **`msrv-base`** (1.88: lib build + lib tests + a v4-free macro probe + a negative assertion that default-tier output fails on 1.88) and **`msrv-avx512`** (1.89: avx512 feature). The 6-platform matrix (incl. `windows-11-arm`, macOS Intel) is preserved on both.

Lowering a declared MSRV is semver-safe (strictly more permissive — adds supported toolchains, breaks nobody).

## Out of scope / future option

archmage's own avx512 path could in principle be version-gated to fall back to AVX2 on 1.88, but `safe_unaligned_simd`'s avx512 module is a dependency and can't be gated from here — so the `avx512` feature is dep-floored at 1.89. Closing that would require either upstream gating in `safe_unaligned_simd` or making archmage's avx512 path avoid the dep's avx512 ops.